### PR TITLE
Implement optimise media worker handler

### DIFF
--- a/internal/handler/worker/optimise_media.go
+++ b/internal/handler/worker/optimise_media.go
@@ -1,0 +1,31 @@
+package worker
+
+import (
+	"context"
+	"log"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/task"
+	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"github.com/google/uuid"
+)
+
+// OptimiseMediaHandler handles an optimise-media task.
+// It converts the incoming task payload to the input expected by
+// the media.Optimiser service and delegates the call.
+func OptimiseMediaHandler(ctx context.Context, p task.OptimiseMediaPayload, svc media.Optimiser) error {
+	id, err := uuid.Parse(p.MediaID)
+	if err != nil {
+		log.Printf("❌  Invalid media ID %q: %v", p.MediaID, err)
+		return err
+	}
+
+	in := media.OptimiseMediaInput{ID: db.UUID(id)}
+	if err := svc.OptimiseMedia(ctx, in); err != nil {
+		log.Printf("❌  Failed to optimise media #%s: %v", id, err)
+		return err
+	}
+
+	log.Printf("✅  Successfully optimised media #%s", id)
+	return nil
+}


### PR DESCRIPTION
## Summary
- add worker handler for optimise media tasks
- log failures with a cross emoji and successes with a green tick

## Testing
- `make clean`
- `make test` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_684575503d5c832182dd2c81f67d0bb4