### PR TITLE
Add worker handler tests

### DIFF
--- a/internal/handler/worker/optimise_media_test.go
+++ b/internal/handler/worker/optimise_media_test.go
@@ -35,7 +35,7 @@ func TestOptimiseMediaHandler_InvalidID(t *testing.T) {
 }
 
 func TestOptimiseMediaHandler_ServiceError(t *testing.T) {
-	id := uuid.New()
+	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	svcErr := errors.New("svc fail")
 	svc := &mockOptimiser{err: svcErr}
 
@@ -46,13 +46,13 @@ func TestOptimiseMediaHandler_ServiceError(t *testing.T) {
 	if !svc.called {
 		t.Error("service not called")
 	}
-	if svc.in.ID != db.UUID(id) {
+	if svc.in.ID != id {
 		t.Errorf("service got id %s; want %s", svc.in.ID, id)
 	}
 }
 
 func TestOptimiseMediaHandler_Success(t *testing.T) {
-	id := uuid.New()
+	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	svc := &mockOptimiser{}
 
 	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{MediaID: id.String()}, svc)
@@ -62,7 +62,7 @@ func TestOptimiseMediaHandler_Success(t *testing.T) {
 	if !svc.called {
 		t.Error("service not called")
 	}
-	if svc.in.ID != db.UUID(id) {
+	if svc.in.ID != id {
 		t.Errorf("service got id %s; want %s", svc.in.ID, id)
 	}
 }

--- a/internal/handler/worker/optimise_media_test.go
+++ b/internal/handler/worker/optimise_media_test.go
@@ -1,0 +1,68 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/task"
+	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"github.com/google/uuid"
+)
+
+type mockOptimiser struct {
+	in     mediaSvc.OptimiseMediaInput
+	called bool
+	err    error
+}
+
+func (m *mockOptimiser) OptimiseMedia(ctx context.Context, in mediaSvc.OptimiseMediaInput) error {
+	m.called = true
+	m.in = in
+	return m.err
+}
+
+func TestOptimiseMediaHandler_InvalidID(t *testing.T) {
+	svc := &mockOptimiser{}
+	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{MediaID: "invalid"}, svc)
+	if err == nil {
+		t.Fatal("expected error for invalid UUID")
+	}
+	if svc.called {
+		t.Error("service should not be called on invalid id")
+	}
+}
+
+func TestOptimiseMediaHandler_ServiceError(t *testing.T) {
+	id := uuid.New()
+	svcErr := errors.New("svc fail")
+	svc := &mockOptimiser{err: svcErr}
+
+	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{MediaID: id.String()}, svc)
+	if !errors.Is(err, svcErr) {
+		t.Fatalf("got error %v; want %v", err, svcErr)
+	}
+	if !svc.called {
+		t.Error("service not called")
+	}
+	if svc.in.ID != db.UUID(id) {
+		t.Errorf("service got id %s; want %s", svc.in.ID, id)
+	}
+}
+
+func TestOptimiseMediaHandler_Success(t *testing.T) {
+	id := uuid.New()
+	svc := &mockOptimiser{}
+
+	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{MediaID: id.String()}, svc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !svc.called {
+		t.Error("service not called")
+	}
+	if svc.in.ID != db.UUID(id) {
+		t.Errorf("service got id %s; want %s", svc.in.ID, id)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for worker OptimiseMediaHandler

## Testing
- `golangci-lint run`
- `go test ./...`
- `cd test/e2e && go test ./...` *(fails: could not start mariadb container)*
- `cd test/integration && go test ./...` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_6845910e5444832189e221204d13ddac