### PR TITLE
Add optimisation task dispatch on finalise

### DIFF
--- a/internal/task/dispatcher.go
+++ b/internal/task/dispatcher.go
@@ -1,0 +1,32 @@
+package task
+
+import (
+	"context"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	media "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"github.com/hibiken/asynq"
+)
+
+type Dispatcher struct {
+	client *asynq.Client
+}
+
+// compile-time check
+var _ media.TaskDispatcher = (*Dispatcher)(nil)
+
+func NewDispatcher(addr, password string) *Dispatcher {
+	c := asynq.NewClient(asynq.RedisClientOpt{Addr: addr, Password: password})
+	return &Dispatcher{client: c}
+}
+
+func (d *Dispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error {
+	t, err := NewOptimiseMediaTask(id.String())
+	if err != nil {
+		return err
+	}
+	if _, err := d.client.EnqueueContext(ctx, t); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/task/noop_dispatcher.go
+++ b/internal/task/noop_dispatcher.go
@@ -1,0 +1,18 @@
+package task
+
+import (
+	"context"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	media "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+)
+
+type NoopDispatcher struct{}
+
+var _ media.TaskDispatcher = (*NoopDispatcher)(nil)
+
+func NewNoopDispatcher() *NoopDispatcher { return &NoopDispatcher{} }
+
+func (d *NoopDispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error {
+	return nil
+}

--- a/internal/usecase/media/interfaces.go
+++ b/internal/usecase/media/interfaces.go
@@ -42,3 +42,7 @@ type FileOptimiser interface {
 	Compress(mimeType string, r io.Reader) (io.ReadCloser, string, error)
 	Resize(mimeType string, r io.Reader, width, height int) (io.ReadCloser, error)
 }
+
+type TaskDispatcher interface {
+	EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error
+}

--- a/internal/usecase/media/mocks.go
+++ b/internal/usecase/media/mocks.go
@@ -181,3 +181,15 @@ func (m *mockFileOptimiser) Resize(mimeType string, r io.Reader, width, height i
 	}
 	return io.NopCloser(bytes.NewReader(m.resizeOut)), nil
 }
+
+type mockDispatcher struct {
+	optimiseCalled bool
+	id             db.UUID
+	optimiseErr    error
+}
+
+func (m *mockDispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error {
+	m.optimiseCalled = true
+	m.id = id
+	return m.optimiseErr
+}

--- a/test/e2e/upload_pdf_test.go
+++ b/test/e2e/upload_pdf_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/migration"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
+	"github.com/fhuszti/medias-ms-go/internal/task"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/fhuszti/medias-ms-go/test/testutil"
 	"github.com/go-chi/chi/v5"
@@ -44,7 +45,7 @@ func TestUploadImageE2E(t *testing.T) {
 	// Initialize repo and services
 	repo := mariadb.NewMediaRepository(dbConn)
 	uploadLinkSvc := mediaSvc.NewUploadLinkGenerator(repo, GlobalStrg, db.NewUUID)
-	finaliserSvc := mediaSvc.NewUploadFinaliser(repo, GlobalStrg)
+	finaliserSvc := mediaSvc.NewUploadFinaliser(repo, GlobalStrg, task.NewNoopDispatcher())
 	ca := cache.NewNoop()
 	getterSvc := mediaSvc.NewMediaGetter(repo, ca, GlobalStrg)
 
@@ -204,7 +205,7 @@ func TestUploadMarkdownE2E(t *testing.T) {
 	// Initialize repo and services
 	repo := mariadb.NewMediaRepository(dbConn)
 	uploadLinkSvc := mediaSvc.NewUploadLinkGenerator(repo, GlobalStrg, db.NewUUID)
-	finaliserSvc := mediaSvc.NewUploadFinaliser(repo, GlobalStrg)
+	finaliserSvc := mediaSvc.NewUploadFinaliser(repo, GlobalStrg, task.NewNoopDispatcher())
 	ca := cache.NewNoop()
 	getterSvc := mediaSvc.NewMediaGetter(repo, ca, GlobalStrg)
 
@@ -370,7 +371,7 @@ func TestUploadPDFE2E(t *testing.T) {
 	// Initialize repo and services
 	repo := mariadb.NewMediaRepository(dbConn)
 	uploadLinkSvc := mediaSvc.NewUploadLinkGenerator(repo, GlobalStrg, db.NewUUID)
-	finaliserSvc := mediaSvc.NewUploadFinaliser(repo, GlobalStrg)
+	finaliserSvc := mediaSvc.NewUploadFinaliser(repo, GlobalStrg, task.NewNoopDispatcher())
 	ca := cache.NewNoop()
 	getterSvc := mediaSvc.NewMediaGetter(repo, ca, GlobalStrg)
 

--- a/test/integration/finalise_upload_test.go
+++ b/test/integration/finalise_upload_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/migration"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
+	"github.com/fhuszti/medias-ms-go/internal/task"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/fhuszti/medias-ms-go/test/testutil"
 	"github.com/go-chi/chi/v5"
@@ -40,7 +41,7 @@ func TestFinaliseUploadIntegration_SuccessMarkdown(t *testing.T) {
 	defer bCleanup()
 
 	mediaRepo := mariadb.NewMediaRepository(database)
-	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg)
+	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg, task.NewNoopDispatcher())
 
 	// Prepare media record and staging file
 	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
@@ -172,7 +173,7 @@ func TestFinaliseUploadIntegration_SuccessImage(t *testing.T) {
 
 	// Initialise service
 	mediaRepo := mariadb.NewMediaRepository(database)
-	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg)
+	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg, task.NewNoopDispatcher())
 
 	// Prepare a media record and staging file (PNG)
 	id := db.UUID(uuid.MustParse("bbbbbbbb-cccc-dddd-eeee-ffffffffffff"))
@@ -305,7 +306,7 @@ func TestFinaliseUploadIntegration_SuccessPDF(t *testing.T) {
 
 	// Initialise service
 	mediaRepo := mariadb.NewMediaRepository(database)
-	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg)
+	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg, task.NewNoopDispatcher())
 
 	// Prepare media record and a staging file (PDF)
 	id := db.UUID(uuid.MustParse("cccccccc-dddd-eeee-ffff-000000000000"))
@@ -431,7 +432,7 @@ func TestFinaliseUploadIntegration_Idempotency(t *testing.T) {
 
 	// Initialise service
 	mediaRepo := mariadb.NewMediaRepository(database)
-	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg)
+	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg, task.NewNoopDispatcher())
 
 	// Prepare a Markdown payload in staging
 	id := db.UUID(uuid.MustParse("dddddddd-eeee-ffff-0000-111111111111"))
@@ -533,7 +534,7 @@ func TestFinaliseUploadIntegration_ErrorFileSize(t *testing.T) {
 
 	// Initialise service
 	mediaRepo := mariadb.NewMediaRepository(dbConn)
-	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg)
+	svc := mediaSvc.NewUploadFinaliser(mediaRepo, GlobalStrg, task.NewNoopDispatcher())
 
 	// Prepare an undersized Markdown file
 	id := db.UUID(uuid.MustParse("eeeeeeee-ffff-0000-1111-222222222222"))


### PR DESCRIPTION
## Summary
- enqueue optimise-media task after upload finalisation
- add TaskDispatcher interface and Asynq-backed implementation
- wire dispatcher in API main
- update mocks and tests for new behaviour

## Testing
- `go test ./...`
- `cd test/e2e && go test ./...` *(fails: could not start mariadb container)*
- `cd test/integration && go test ./...` *(fails: could not start mariadb container)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_684626070f3c8321a3fd3bb3c729f47b