### PR TITLE
Implement image resize worker handler

### DIFF
--- a/internal/handler/worker/resize_image.go
+++ b/internal/handler/worker/resize_image.go
@@ -6,25 +6,25 @@ import (
 
 	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"github.com/fhuszti/medias-ms-go/internal/validation"
 	"github.com/google/uuid"
 )
 
 // ResizeImagePayload represents the payload for a resize-image task.
 type ResizeImagePayload struct {
-	MediaID string `json:"media_id"`
-	Sizes   []int  `json:"sizes"`
+	MediaID string `json:"media_id" validate:"required,uuid"`
 }
 
 // ResizeImageHandler handles a resize-image task.
 // It validates the incoming payload and delegates the call to the service.
-func ResizeImageHandler(ctx context.Context, p ResizeImagePayload, svc media.ImageResizer) error {
-	id, err := uuid.Parse(p.MediaID)
-	if err != nil {
-		log.Printf("❌  Invalid media ID %q: %v", p.MediaID, err)
+func ResizeImageHandler(ctx context.Context, p ResizeImagePayload, sizes []int, svc media.ImageResizer) error {
+	if err := validation.ValidateStruct(p); err != nil {
+		log.Printf("❌  Payload validation failed: %v", err)
 		return err
 	}
 
-	in := media.ResizeImageInput{ID: db.UUID(id), Sizes: p.Sizes}
+	id := uuid.MustParse(p.MediaID)
+	in := media.ResizeImageInput{ID: db.UUID(id), Sizes: sizes}
 	if err := svc.ResizeImage(ctx, in); err != nil {
 		log.Printf("❌  Failed to resize image #%s: %v", id, err)
 		return err

--- a/internal/handler/worker/resize_image.go
+++ b/internal/handler/worker/resize_image.go
@@ -12,7 +12,7 @@ import (
 
 // ResizeImagePayload represents the payload for a resize-image task.
 type ResizeImagePayload struct {
-	MediaID string `json:"media_id" validate:"required,uuid"`
+	ID string `json:"id" validate:"required,uuid"`
 }
 
 // ResizeImageHandler handles a resize-image task.
@@ -23,7 +23,7 @@ func ResizeImageHandler(ctx context.Context, p ResizeImagePayload, sizes []int, 
 		return err
 	}
 
-	id := uuid.MustParse(p.MediaID)
+	id := uuid.MustParse(p.ID)
 	in := media.ResizeImageInput{ID: db.UUID(id), Sizes: sizes}
 	if err := svc.ResizeImage(ctx, in); err != nil {
 		log.Printf("❌  Failed to resize image #%s: %v", id, err)

--- a/internal/handler/worker/resize_image.go
+++ b/internal/handler/worker/resize_image.go
@@ -1,0 +1,35 @@
+package worker
+
+import (
+	"context"
+	"log"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"github.com/google/uuid"
+)
+
+// ResizeImagePayload represents the payload for a resize-image task.
+type ResizeImagePayload struct {
+	MediaID string `json:"media_id"`
+	Sizes   []int  `json:"sizes"`
+}
+
+// ResizeImageHandler handles a resize-image task.
+// It validates the incoming payload and delegates the call to the service.
+func ResizeImageHandler(ctx context.Context, p ResizeImagePayload, svc media.ImageResizer) error {
+	id, err := uuid.Parse(p.MediaID)
+	if err != nil {
+		log.Printf("❌  Invalid media ID %q: %v", p.MediaID, err)
+		return err
+	}
+
+	in := media.ResizeImageInput{ID: db.UUID(id), Sizes: p.Sizes}
+	if err := svc.ResizeImage(ctx, in); err != nil {
+		log.Printf("❌  Failed to resize image #%s: %v", id, err)
+		return err
+	}
+
+	log.Printf("✅  Successfully resized image #%s", id)
+	return nil
+}

--- a/internal/handler/worker/resize_image_test.go
+++ b/internal/handler/worker/resize_image_test.go
@@ -24,7 +24,7 @@ func (m *mockResizer) ResizeImage(ctx context.Context, in mediaSvc.ResizeImageIn
 
 func TestResizeImageHandler_InvalidID(t *testing.T) {
 	svc := &mockResizer{}
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: "invalid"}, svc)
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: "invalid"}, nil, svc)
 	if err == nil {
 		t.Fatal("expected error for invalid UUID")
 	}
@@ -39,7 +39,7 @@ func TestResizeImageHandler_ServiceError(t *testing.T) {
 	svc := &mockResizer{err: svcErr}
 
 	sizes := []int{100, 200}
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: id.String(), Sizes: sizes}, svc)
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: id.String()}, sizes, svc)
 	if !errors.Is(err, svcErr) {
 		t.Fatalf("got error %v; want %v", err, svcErr)
 	}
@@ -59,7 +59,7 @@ func TestResizeImageHandler_Success(t *testing.T) {
 	svc := &mockResizer{}
 	sizes := []int{100, 200}
 
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: id.String(), Sizes: sizes}, svc)
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: id.String()}, sizes, svc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/handler/worker/resize_image_test.go
+++ b/internal/handler/worker/resize_image_test.go
@@ -1,0 +1,75 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"github.com/google/uuid"
+)
+
+type mockResizer struct {
+	in     mediaSvc.ResizeImageInput
+	called bool
+	err    error
+}
+
+func (m *mockResizer) ResizeImage(ctx context.Context, in mediaSvc.ResizeImageInput) error {
+	m.called = true
+	m.in = in
+	return m.err
+}
+
+func TestResizeImageHandler_InvalidID(t *testing.T) {
+	svc := &mockResizer{}
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: "invalid"}, svc)
+	if err == nil {
+		t.Fatal("expected error for invalid UUID")
+	}
+	if svc.called {
+		t.Error("service should not be called on invalid id")
+	}
+}
+
+func TestResizeImageHandler_ServiceError(t *testing.T) {
+	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	svcErr := errors.New("svc fail")
+	svc := &mockResizer{err: svcErr}
+
+	sizes := []int{100, 200}
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: id.String(), Sizes: sizes}, svc)
+	if !errors.Is(err, svcErr) {
+		t.Fatalf("got error %v; want %v", err, svcErr)
+	}
+	if !svc.called {
+		t.Error("service not called")
+	}
+	if svc.in.ID != id {
+		t.Errorf("service got id %s; want %s", svc.in.ID, id)
+	}
+	if len(svc.in.Sizes) != len(sizes) {
+		t.Errorf("service got sizes %v; want %v", svc.in.Sizes, sizes)
+	}
+}
+
+func TestResizeImageHandler_Success(t *testing.T) {
+	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	svc := &mockResizer{}
+	sizes := []int{100, 200}
+
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: id.String(), Sizes: sizes}, svc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !svc.called {
+		t.Error("service not called")
+	}
+	if svc.in.ID != id {
+		t.Errorf("service got id %s; want %s", svc.in.ID, id)
+	}
+	if len(svc.in.Sizes) != len(sizes) {
+		t.Errorf("service got sizes %v; want %v", svc.in.Sizes, sizes)
+	}
+}

--- a/internal/handler/worker/resize_image_test.go
+++ b/internal/handler/worker/resize_image_test.go
@@ -24,7 +24,7 @@ func (m *mockResizer) ResizeImage(ctx context.Context, in mediaSvc.ResizeImageIn
 
 func TestResizeImageHandler_InvalidID(t *testing.T) {
 	svc := &mockResizer{}
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: "invalid"}, nil, svc)
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{ID: "invalid"}, nil, svc)
 	if err == nil {
 		t.Fatal("expected error for invalid UUID")
 	}
@@ -39,7 +39,7 @@ func TestResizeImageHandler_ServiceError(t *testing.T) {
 	svc := &mockResizer{err: svcErr}
 
 	sizes := []int{100, 200}
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: id.String()}, sizes, svc)
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{ID: id.String()}, sizes, svc)
 	if !errors.Is(err, svcErr) {
 		t.Fatalf("got error %v; want %v", err, svcErr)
 	}
@@ -59,7 +59,7 @@ func TestResizeImageHandler_Success(t *testing.T) {
 	svc := &mockResizer{}
 	sizes := []int{100, 200}
 
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{MediaID: id.String()}, sizes, svc)
+	err := ResizeImageHandler(context.Background(), ResizeImagePayload{ID: id.String()}, sizes, svc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add resize image worker handler
- create unit tests covering error cases and success

## Testing
- `go test ./...`
- `cd test/e2e && go test ./...` *(fails: could not start mariadb container)*
- `cd test/integration && go test ./...` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_68470618d37c8321b3260acf81757cb0