### PR TITLE
Move resize payload to task package

### DIFF
--- a/internal/handler/worker/optimise_media.go
+++ b/internal/handler/worker/optimise_media.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/task"
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"github.com/fhuszti/medias-ms-go/internal/validation"
 	"github.com/google/uuid"
 )
 
@@ -14,11 +15,12 @@ import (
 // It converts the incoming task payload to the input expected by
 // the media.Optimiser service and delegates the call.
 func OptimiseMediaHandler(ctx context.Context, p task.OptimiseMediaPayload, svc media.Optimiser) error {
-	id, err := uuid.Parse(p.MediaID)
-	if err != nil {
-		log.Printf("❌  Invalid media ID %q: %v", p.MediaID, err)
+	if err := validation.ValidateStruct(p); err != nil {
+		log.Printf("❌  Payload validation failed: %v", err)
 		return err
 	}
+
+	id := uuid.MustParse(p.ID)
 
 	in := media.OptimiseMediaInput{ID: db.UUID(id)}
 	if err := svc.OptimiseMedia(ctx, in); err != nil {

--- a/internal/handler/worker/optimise_media_test.go
+++ b/internal/handler/worker/optimise_media_test.go
@@ -25,7 +25,7 @@ func (m *mockOptimiser) OptimiseMedia(ctx context.Context, in mediaSvc.OptimiseM
 
 func TestOptimiseMediaHandler_InvalidID(t *testing.T) {
 	svc := &mockOptimiser{}
-	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{MediaID: "invalid"}, svc)
+	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{ID: "invalid"}, svc)
 	if err == nil {
 		t.Fatal("expected error for invalid UUID")
 	}
@@ -39,7 +39,7 @@ func TestOptimiseMediaHandler_ServiceError(t *testing.T) {
 	svcErr := errors.New("svc fail")
 	svc := &mockOptimiser{err: svcErr}
 
-	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{MediaID: id.String()}, svc)
+	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{ID: id.String()}, svc)
 	if !errors.Is(err, svcErr) {
 		t.Fatalf("got error %v; want %v", err, svcErr)
 	}
@@ -55,7 +55,7 @@ func TestOptimiseMediaHandler_Success(t *testing.T) {
 	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	svc := &mockOptimiser{}
 
-	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{MediaID: id.String()}, svc)
+	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{ID: id.String()}, svc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/handler/worker/resize_image.go
+++ b/internal/handler/worker/resize_image.go
@@ -5,19 +5,15 @@ import (
 	"log"
 
 	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/task"
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/fhuszti/medias-ms-go/internal/validation"
 	"github.com/google/uuid"
 )
 
-// ResizeImagePayload represents the payload for a resize-image task.
-type ResizeImagePayload struct {
-	ID string `json:"id" validate:"required,uuid"`
-}
-
 // ResizeImageHandler handles a resize-image task.
 // It validates the incoming payload and delegates the call to the service.
-func ResizeImageHandler(ctx context.Context, p ResizeImagePayload, sizes []int, svc media.ImageResizer) error {
+func ResizeImageHandler(ctx context.Context, p task.ResizeImagePayload, sizes []int, svc media.ImageResizer) error {
 	if err := validation.ValidateStruct(p); err != nil {
 		log.Printf("❌  Payload validation failed: %v", err)
 		return err

--- a/internal/handler/worker/resize_image_test.go
+++ b/internal/handler/worker/resize_image_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/task"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/google/uuid"
 )
@@ -24,7 +25,7 @@ func (m *mockResizer) ResizeImage(ctx context.Context, in mediaSvc.ResizeImageIn
 
 func TestResizeImageHandler_InvalidID(t *testing.T) {
 	svc := &mockResizer{}
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{ID: "invalid"}, nil, svc)
+	err := ResizeImageHandler(context.Background(), task.ResizeImagePayload{ID: "invalid"}, nil, svc)
 	if err == nil {
 		t.Fatal("expected error for invalid UUID")
 	}
@@ -39,7 +40,7 @@ func TestResizeImageHandler_ServiceError(t *testing.T) {
 	svc := &mockResizer{err: svcErr}
 
 	sizes := []int{100, 200}
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{ID: id.String()}, sizes, svc)
+	err := ResizeImageHandler(context.Background(), task.ResizeImagePayload{ID: id.String()}, sizes, svc)
 	if !errors.Is(err, svcErr) {
 		t.Fatalf("got error %v; want %v", err, svcErr)
 	}
@@ -59,7 +60,7 @@ func TestResizeImageHandler_Success(t *testing.T) {
 	svc := &mockResizer{}
 	sizes := []int{100, 200}
 
-	err := ResizeImageHandler(context.Background(), ResizeImagePayload{ID: id.String()}, sizes, svc)
+	err := ResizeImageHandler(context.Background(), task.ResizeImagePayload{ID: id.String()}, sizes, svc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/task/dispatcher.go
+++ b/internal/task/dispatcher.go
@@ -30,3 +30,14 @@ func (d *Dispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error
 	}
 	return nil
 }
+
+func (d *Dispatcher) EnqueueResizeImage(ctx context.Context, id db.UUID) error {
+	t, err := NewResizeImageTask(id.String())
+	if err != nil {
+		return err
+	}
+	if _, err := d.client.EnqueueContext(ctx, t); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/task/tasks.go
+++ b/internal/task/tasks.go
@@ -8,14 +8,19 @@ import (
 )
 
 const TypeOptimiseMedia = "media:optimise"
+const TypeResizeImage = "image:resize"
 
 type OptimiseMediaPayload struct {
-	MediaID string `json:"media_id"`
+	ID string `json:"id" validate:"required,uuid"`
+}
+
+type ResizeImagePayload struct {
+	ID string `json:"id" validate:"required,uuid"`
 }
 
 // NewOptimiseMediaTask creates an Asynq task for optimising a media by ID.
-func NewOptimiseMediaTask(mediaID string) (*asynq.Task, error) {
-	p := OptimiseMediaPayload{MediaID: mediaID}
+func NewOptimiseMediaTask(id string) (*asynq.Task, error) {
+	p := OptimiseMediaPayload{ID: id}
 	data, err := json.Marshal(p)
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal optimise-media payload: %w", err)
@@ -28,6 +33,25 @@ func ParseOptimiseMediaPayload(t *asynq.Task) (OptimiseMediaPayload, error) {
 	var p OptimiseMediaPayload
 	if err := json.Unmarshal(t.Payload(), &p); err != nil {
 		return OptimiseMediaPayload{}, fmt.Errorf("could not unmarshal payload: %w", err)
+	}
+	return p, nil
+}
+
+// NewResizeImageTask creates an Asynq task for resizing an image.
+func NewResizeImageTask(id string) (*asynq.Task, error) {
+	p := ResizeImagePayload{ID: id}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal resize-image payload: %w", err)
+	}
+	return asynq.NewTask(TypeResizeImage, data), nil
+}
+
+// ParseResizeImagePayload parses the task payload to ResizeImagePayload.
+func ParseResizeImagePayload(t *asynq.Task) (ResizeImagePayload, error) {
+	var p ResizeImagePayload
+	if err := json.Unmarshal(t.Payload(), &p); err != nil {
+		return ResizeImagePayload{}, fmt.Errorf("could not unmarshal payload: %w", err)
 	}
 	return p, nil
 }


### PR DESCRIPTION
## Summary
- centralize resize task payload and add task helpers
- validate optimise payload, rename `MediaID` to `ID`
- update worker handlers/tests for new payloads
- extend dispatcher with `EnqueueResizeImage`
- address inline review comments about validation locations

## Testing
- `golangci-lint run` *(failed: command timed out)*
- `make test` *(failed: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_684734cede1483218c5b2fcb0865d7f4