### PR TITLE
Implement resize image task

### DIFF
--- a/internal/task/noop_dispatcher.go
+++ b/internal/task/noop_dispatcher.go
@@ -16,3 +16,7 @@ func NewNoopDispatcher() *NoopDispatcher { return &NoopDispatcher{} }
 func (d *NoopDispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error {
 	return nil
 }
+
+func (d *NoopDispatcher) EnqueueResizeImage(ctx context.Context, id db.UUID) error {
+	return nil
+}

--- a/internal/usecase/media/interfaces.go
+++ b/internal/usecase/media/interfaces.go
@@ -45,4 +45,5 @@ type FileOptimiser interface {
 
 type TaskDispatcher interface {
 	EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error
+	EnqueueResizeImage(ctx context.Context, id db.UUID) error
 }

--- a/internal/usecase/media/mocks.go
+++ b/internal/usecase/media/mocks.go
@@ -186,10 +186,20 @@ type mockDispatcher struct {
 	optimiseCalled bool
 	id             db.UUID
 	optimiseErr    error
+
+	resizeCalled bool
+	resizeID     db.UUID
+	resizeErr    error
 }
 
 func (m *mockDispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error {
 	m.optimiseCalled = true
 	m.id = id
 	return m.optimiseErr
+}
+
+func (m *mockDispatcher) EnqueueResizeImage(ctx context.Context, id db.UUID) error {
+	m.resizeCalled = true
+	m.resizeID = id
+	return m.resizeErr
 }


### PR DESCRIPTION
## Summary
- add `EnqueueResizeImage` to task dispatcher interface and noop implementation
- dispatch resize task after media optimisation when image
- update worker to handle resize tasks and instantiate dispatcher
- extend mocks and update tests for resize task enqueueing

## Testing
- `golangci-lint run`
- `make test` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_68473f3471d883219d6c8b6f9ba96180