### PR TITLE
Return no output on finalise upload

### DIFF
--- a/internal/handler/api/finalise_upload.go
+++ b/internal/handler/api/finalise_upload.go
@@ -50,13 +50,12 @@ func FinaliseUploadHandler(svc media.UploadFinaliser) http.HandlerFunc {
 			ID:         db.UUID(id),
 			DestBucket: destBucket,
 		}
-		output, err := svc.FinaliseUpload(r.Context(), input)
-		if err != nil {
+		if err := svc.FinaliseUpload(r.Context(), input); err != nil {
 			WriteError(w, http.StatusInternalServerError, fmt.Sprintf("could not finalise upload of media #%s", input.ID), err)
 			return
 		}
 
-		RespondJSON(w, http.StatusOK, output)
+		w.WriteHeader(http.StatusNoContent)
 		log.Printf("✅  Successfully finalised upload of media #%s", input.ID)
 	}
 }

--- a/internal/handler/api/finalise_upload_test.go
+++ b/internal/handler/api/finalise_upload_test.go
@@ -11,40 +11,29 @@ import (
 	"testing"
 
 	"github.com/fhuszti/medias-ms-go/internal/db"
-	"github.com/fhuszti/medias-ms-go/internal/model"
 	mediaUC "github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/google/uuid"
 )
 
 type mockFinaliser struct {
 	in  mediaUC.FinaliseUploadInput
-	out *model.Media
 	err error
 }
 
-func (m *mockFinaliser) FinaliseUpload(ctx context.Context, in mediaUC.FinaliseUploadInput) (*model.Media, error) {
+func (m *mockFinaliser) FinaliseUpload(ctx context.Context, in mediaUC.FinaliseUploadInput) error {
 	m.in = in
-	return m.out, m.err
+	return m.err
 }
 
 func TestFinaliseUploadHandler(t *testing.T) {
 	validID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
-	sampleMedia := &model.Media{
-		ID:        validID,
-		ObjectKey: "foo.bin",
-		Status:    model.MediaStatusCompleted,
-	}
-
 	tests := []struct {
 		name            string
 		ctxBucket       string
 		body            string
-		svcOut          *model.Media
 		svcErr          error
 		wantStatus      int
 		wantContentType string
-		// one of these:
-		wantJSONObj     interface{}       // pointer to struct for JSON decode
 		wantErrorMap    map[string]string // for validation-error JSON
 		wantBodyContain string            // substring for plain-text errors
 	}{
@@ -93,16 +82,14 @@ func TestFinaliseUploadHandler(t *testing.T) {
 			name:            "happy path",
 			ctxBucket:       "mydest",
 			body:            `{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}`,
-			svcOut:          sampleMedia,
-			wantStatus:      http.StatusOK,
-			wantContentType: "application/json",
-			wantJSONObj:     &model.Media{},
+			wantStatus:      http.StatusNoContent,
+			wantContentType: "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockSvc := &mockFinaliser{out: tc.svcOut, err: tc.svcErr}
+			mockSvc := &mockFinaliser{err: tc.svcErr}
 			h := FinaliseUploadHandler(mockSvc)
 
 			req := httptest.NewRequest(http.MethodPost, "/any", bytes.NewBufferString(tc.body))
@@ -125,25 +112,11 @@ func TestFinaliseUploadHandler(t *testing.T) {
 			}
 
 			body := rec.Body.Bytes()
-
-			switch {
-			case tc.wantJSONObj != nil:
-				// success JSON -> unmarshal into struct and compare fields
-				if err := json.Unmarshal(body, tc.wantJSONObj); err != nil {
-					t.Fatalf("invalid JSON response: %v; body=%s", err, body)
+			if tc.wantStatus == http.StatusNoContent {
+				if len(body) != 0 {
+					t.Errorf("expected empty body, got %q", body)
 				}
-				got := tc.wantJSONObj.(*model.Media)
-				if got.ID != tc.svcOut.ID {
-					t.Errorf("ID = %v; want %v", got.ID, tc.svcOut.ID)
-				}
-				if got.Status != tc.svcOut.Status {
-					t.Errorf("Status = %q; want %q", got.Status, tc.svcOut.Status)
-				}
-				if got.ObjectKey != tc.svcOut.ObjectKey {
-					t.Errorf("ObjectKey = %q; want %q", got.ObjectKey, tc.svcOut.ObjectKey)
-				}
-
-			case tc.wantErrorMap != nil:
+			} else if tc.wantErrorMap != nil {
 				// unmarshal into map[string]string
 				var errs map[string]string
 				if err := json.Unmarshal(body, &errs); err != nil {
@@ -158,7 +131,7 @@ func TestFinaliseUploadHandler(t *testing.T) {
 					}
 				}
 
-			default:
+			} else {
 				// plain-text error
 				if !bytes.Contains(body, []byte(tc.wantBodyContain)) {
 					t.Errorf("body = %q; want to contain %q", body, tc.wantBodyContain)
@@ -166,16 +139,13 @@ func TestFinaliseUploadHandler(t *testing.T) {
 			}
 
 			// If the service was invoked, verify inputs
-			if tc.svcOut != nil || tc.svcErr != nil {
-				// Only invoked when ctxBucket non-empty AND JSON validation passed
-				// Skip check for missing-bucket or invalid-JSON or validation-error
-				if tc.ctxBucket != "" && tc.wantErrorMap == nil && tc.wantBodyContain == "" {
-					if mockSvc.in.DestBucket != tc.ctxBucket {
-						t.Errorf("service got DestBucket = %q; want %q", mockSvc.in.DestBucket, tc.ctxBucket)
-					}
-					if mockSvc.in.ID != validID {
-						t.Errorf("service got ID = %v; want %v", mockSvc.in.ID, validID)
-					}
+			// Only invoked when ctxBucket non-empty AND JSON validation passed
+			if tc.ctxBucket != "" && tc.wantErrorMap == nil && tc.wantBodyContain == "" {
+				if mockSvc.in.DestBucket != tc.ctxBucket {
+					t.Errorf("service got DestBucket = %q; want %q", mockSvc.in.DestBucket, tc.ctxBucket)
+				}
+				if mockSvc.in.ID != validID {
+					t.Errorf("service got ID = %v; want %v", mockSvc.in.ID, validID)
 				}
 			}
 		})

--- a/internal/usecase/media/finalise_upload_test.go
+++ b/internal/usecase/media/finalise_upload_test.go
@@ -19,7 +19,7 @@ func TestFinaliseUpload_ErrGetByID(t *testing.T) {
 	repo := &mockRepo{getErr: errors.New("db fail")}
 	svc := NewUploadFinaliser(repo, &mockStorage{}, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || err.Error() != "db fail" {
 		t.Errorf("expected getByID error, got %v", err)
 	}
@@ -30,12 +30,8 @@ func TestFinaliseUpload_AlreadyCompleted(t *testing.T) {
 	repo := &mockRepo{mediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, &mockStorage{}, &mockDispatcher{})
 
-	out, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
-	if err != nil {
+	if err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if out != mrec {
-		t.Errorf("expected returned media unchanged, got %v", out)
 	}
 }
 
@@ -44,7 +40,7 @@ func TestFinaliseUpload_WrongStatus(t *testing.T) {
 	repo := &mockRepo{mediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, &mockStorage{}, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "media status should be 'pending'") {
 		t.Errorf("expected status error, got %v", err)
 	}
@@ -56,7 +52,7 @@ func TestFinaliseUpload_StatNotFound(t *testing.T) {
 	repo := &mockRepo{mediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, stg, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "staging file \"k\" not found") {
 		t.Errorf("expected not found error, got %v", err)
 	}
@@ -81,7 +77,7 @@ func TestFinaliseUpload_SizeValidation(t *testing.T) {
 		stg := &mockStorage{statInfo: FileInfo{SizeBytes: tc.size, ContentType: "image/png"}}
 		repo := &mockRepo{mediaRecord: mrec}
 		svc := NewUploadFinaliser(repo, stg, &mockDispatcher{})
-		_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+		err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 			t.Errorf("size %d: expected error containing %q, got %v", tc.size, tc.wantErr, err)
 		}
@@ -94,7 +90,7 @@ func TestFinaliseUpload_UnsupportedMime(t *testing.T) {
 	repo := &mockRepo{mediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, stg, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported mime-type") {
 		t.Errorf("expected unsupported mime-type error, got %v", err)
 	}
@@ -106,7 +102,7 @@ func TestFinaliseUpload_MoveGetFileError(t *testing.T) {
 	repo := &mockRepo{mediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, stg, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "can't read file") {
 		t.Errorf("expected getfile error, got %v", err)
 	}
@@ -118,7 +114,7 @@ func TestFinaliseUpload_MoveExtensionError(t *testing.T) {
 	repo := &mockRepo{mediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, stg, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported mime-type") {
 		t.Errorf("expected extension error, got %v", err)
 	}
@@ -130,7 +126,7 @@ func TestFinaliseUpload_MoveMetadataError(t *testing.T) {
 	stg := &mockStorage{statInfo: FileInfo{SizeBytes: MinFileSize, ContentType: "image/png"}, reader: strings.NewReader("not-a-png")}
 	svc := NewUploadFinaliser(repo, stg, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "error decoding") {
 		t.Errorf("expected metadata error, got %v", err)
 	}
@@ -142,7 +138,7 @@ func TestFinaliseUpload_MoveSaveFileError(t *testing.T) {
 	stg := &mockStorage{saveErr: errors.New("save fail"), statInfo: FileInfo{SizeBytes: MinFileSize, ContentType: "image/png"}, reader: getPNGReader(t)}
 	svc := NewUploadFinaliser(repo, stg, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "save fail") {
 		t.Errorf("expected savefile error, got %v", err)
 	}
@@ -154,7 +150,7 @@ func TestFinaliseUpload_MoveUpdateMediaError(t *testing.T) {
 	stg := &mockStorage{statInfo: FileInfo{SizeBytes: MinFileSize, ContentType: "image/png"}, reader: getPNGReader(t)}
 	svc := NewUploadFinaliser(repo, stg, &mockDispatcher{})
 
-	_, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "update fail") {
 		t.Errorf("expected repo update error, got %v", err)
 	}
@@ -167,15 +163,14 @@ func TestFinaliseUpload_Success(t *testing.T) {
 	dispatcher := &mockDispatcher{}
 	svc := NewUploadFinaliser(repo, stg, dispatcher)
 
-	out, err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
-	if err != nil {
+	if err := svc.FinaliseUpload(context.Background(), FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if out.Bucket != "images" {
-		t.Errorf("bucket should be 'images', got %q", out.Bucket)
+	if mrec.Bucket != "images" {
+		t.Errorf("bucket should be 'images', got %q", mrec.Bucket)
 	}
-	if out.Status != model.MediaStatusCompleted {
-		t.Errorf("Status = %q; want Completed", out.Status)
+	if mrec.Status != model.MediaStatusCompleted {
+		t.Errorf("Status = %q; want Completed", mrec.Status)
 	}
 	if !stg.saveCalled {
 		t.Error("expected SaveFile on destination to be called")

--- a/test/integration/finalise_upload_test.go
+++ b/test/integration/finalise_upload_test.go
@@ -72,38 +72,11 @@ func TestFinaliseUploadIntegration_SuccessMarkdown(t *testing.T) {
 		t.Fatalf("upload to staging: %v", err)
 	}
 
-	out, err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{
+	if err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{
 		ID:         id,
 		DestBucket: "docs",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("FinaliseUpload returned error: %v", err)
-	}
-
-	// Assert returned media
-	if out.ID != id {
-		t.Errorf("returned ID = %v; want %v", out.ID, id)
-	}
-	if out.Bucket != "docs" {
-		t.Errorf("bucket should be 'docs', got %q", out.Bucket)
-	}
-	if out.Status != model.MediaStatusCompleted {
-		t.Errorf("returned Status = %q; want %q", out.Status, model.MediaStatusCompleted)
-	}
-	if out.SizeBytes == nil || *out.SizeBytes != int64(len(content)) {
-		t.Errorf("returned SizeBytes = %v; want %v", out.SizeBytes, len(content))
-	}
-	if out.MimeType == nil || *out.MimeType != "text/markdown" {
-		t.Errorf("returned MimeType = %q; want %q", *out.MimeType, "text/markdown")
-	}
-	if out.Metadata.WordCount != 23 {
-		t.Errorf("WordCount = %d; want %d", out.Metadata.WordCount, 23)
-	}
-	if out.Metadata.HeadingCount != 3 {
-		t.Errorf("HeadingCount = %d; want %d", out.Metadata.HeadingCount, 3)
-	}
-	if out.Metadata.LinkCount != 2 {
-		t.Errorf("LinkCount = %d; want %d", out.Metadata.LinkCount, 2)
 	}
 
 	// Assert DB was updated
@@ -205,37 +178,11 @@ func TestFinaliseUploadIntegration_SuccessImage(t *testing.T) {
 	}
 
 	// Execute finalisation
-	out, err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{
+	if err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{
 		ID:         id,
 		DestBucket: "images",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("FinaliseUpload returned error: %v", err)
-	}
-
-	// Basic assertions
-	if out.ID != id {
-		t.Errorf("returned ID = %v; want %v", out.ID, id)
-	}
-	if out.Bucket != "images" {
-		t.Errorf("bucket should be 'images', got %q", out.Bucket)
-	}
-	if out.Status != model.MediaStatusCompleted {
-		t.Errorf("returned Status = %q; want %q", out.Status, model.MediaStatusCompleted)
-	}
-	if out.SizeBytes == nil || *out.SizeBytes != int64(len(content)) {
-		t.Errorf("returned SizeBytes = %v; want %v", out.SizeBytes, len(content))
-	}
-	if out.MimeType == nil || *out.MimeType != "image/png" {
-		t.Errorf("returned MimeType = %q; want %q", *out.MimeType, "image/png")
-	}
-
-	// Assert image metadata
-	if out.Metadata.Width != width {
-		t.Errorf("Metadata.Width = %d; want %d", out.Metadata.Width, width)
-	}
-	if out.Metadata.Height != height {
-		t.Errorf("Metadata.Height = %d; want %d", out.Metadata.Height, height)
 	}
 
 	// Assert DB updated
@@ -243,11 +190,23 @@ func TestFinaliseUploadIntegration_SuccessImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
 	}
-	if fromDB.Metadata.Width != out.Metadata.Width {
-		t.Errorf("DB Metadata.Width = %d; want %d", fromDB.Metadata.Width, out.Metadata.Width)
+	if fromDB.Bucket != "images" {
+		t.Errorf("bucket should be 'images', got %q", fromDB.Bucket)
 	}
-	if fromDB.Metadata.Height != out.Metadata.Height {
-		t.Errorf("DB Metadata.Height = %d; want %d", fromDB.Metadata.Height, out.Metadata.Height)
+	if fromDB.Status != model.MediaStatusCompleted {
+		t.Errorf("DB Status = %q; want %q", fromDB.Status, model.MediaStatusCompleted)
+	}
+	if fromDB.SizeBytes == nil || *fromDB.SizeBytes != int64(len(content)) {
+		t.Errorf("DB SizeBytes = %v; want %v", fromDB.SizeBytes, len(content))
+	}
+	if fromDB.MimeType == nil || *fromDB.MimeType != "image/png" {
+		t.Errorf("DB MimeType = %q; want %q", *fromDB.MimeType, "image/png")
+	}
+	if fromDB.Metadata.Width != width {
+		t.Errorf("Metadata.Width = %d; want %d", fromDB.Metadata.Width, width)
+	}
+	if fromDB.Metadata.Height != height {
+		t.Errorf("Metadata.Height = %d; want %d", fromDB.Metadata.Height, height)
 	}
 
 	// Assert file moved to destination
@@ -337,34 +296,11 @@ func TestFinaliseUploadIntegration_SuccessPDF(t *testing.T) {
 	}
 
 	// Execute finalisation
-	out, err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{
+	if err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{
 		ID:         id,
 		DestBucket: "docs",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("FinaliseUpload returned error: %v", err)
-	}
-
-	// Basic assertions
-	if out.ID != id {
-		t.Errorf("returned ID = %v; want %v", out.ID, id)
-	}
-	if out.Bucket != "docs" {
-		t.Errorf("bucket should be 'docs', got %q", out.Bucket)
-	}
-	if out.Status != model.MediaStatusCompleted {
-		t.Errorf("returned Status = %q; want %q", out.Status, model.MediaStatusCompleted)
-	}
-	if out.SizeBytes == nil || *out.SizeBytes != int64(len(content)) {
-		t.Errorf("returned SizeBytes = %v; want %v", out.SizeBytes, len(content))
-	}
-	if out.MimeType == nil || *out.MimeType != "application/pdf" {
-		t.Errorf("returned MimeType = %q; want %q", *out.MimeType, "application/pdf")
-	}
-
-	// Assert PDF metadata
-	if out.Metadata.PageCount != 4 {
-		t.Errorf("PageCount = %d; want %d", out.Metadata.PageCount, 4)
 	}
 
 	// Assert DB updated
@@ -372,8 +308,20 @@ func TestFinaliseUploadIntegration_SuccessPDF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
 	}
-	if fromDB.Metadata.PageCount != out.Metadata.PageCount {
-		t.Errorf("DB PageCount = %d; want %d", fromDB.Metadata.PageCount, out.Metadata.PageCount)
+	if fromDB.Bucket != "docs" {
+		t.Errorf("bucket should be 'docs', got %q", fromDB.Bucket)
+	}
+	if fromDB.Status != model.MediaStatusCompleted {
+		t.Errorf("DB Status = %q; want %q", fromDB.Status, model.MediaStatusCompleted)
+	}
+	if fromDB.SizeBytes == nil || *fromDB.SizeBytes != int64(len(content)) {
+		t.Errorf("DB SizeBytes = %v; want %v", fromDB.SizeBytes, len(content))
+	}
+	if fromDB.MimeType == nil || *fromDB.MimeType != "application/pdf" {
+		t.Errorf("DB MimeType = %q; want %q", *fromDB.MimeType, "application/pdf")
+	}
+	if fromDB.Metadata.PageCount != 4 {
+		t.Errorf("PageCount = %d; want %d", fromDB.Metadata.PageCount, 4)
 	}
 
 	// Assert file moved to destination
@@ -454,23 +402,30 @@ func TestFinaliseUploadIntegration_Idempotency(t *testing.T) {
 	}
 
 	// First call: expect success
-	out1, err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{ID: id, DestBucket: "docs"})
-	if err != nil {
+	if err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{ID: id, DestBucket: "docs"}); err != nil {
 		t.Fatalf("first FinaliseUpload error: %v", err)
+	}
+
+	out1, err := mediaRepo.GetByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
 	}
 	if out1.Status != model.MediaStatusCompleted {
 		t.Errorf("first call Status = %q; want %q", out1.Status, model.MediaStatusCompleted)
 	}
 
 	// Second call: should be no-op, return existing
-	out2, err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{ID: id, DestBucket: "docs"})
-	if err != nil {
+	if err := svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{ID: id, DestBucket: "docs"}); err != nil {
 		t.Fatalf("second FinaliseUpload error: %v", err)
+	}
+
+	out2, err := mediaRepo.GetByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
 	}
 	if out2.Status != model.MediaStatusCompleted {
 		t.Errorf("second call Status = %q; want %q", out2.Status, model.MediaStatusCompleted)
 	}
-	// Should not change object key or bucket
 	if out2.Bucket != out1.Bucket {
 		t.Errorf("second call Bucket = %q; want %q", out2.Bucket, out1.Bucket)
 	}
@@ -565,7 +520,7 @@ func TestFinaliseUploadIntegration_ErrorFileSize(t *testing.T) {
 	}
 
 	// Attempt finalisation: expect "too small" error
-	_, err = svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{ID: id, DestBucket: "docs"})
+	err = svc.FinaliseUpload(ctx, mediaSvc.FinaliseUploadInput{ID: id, DestBucket: "docs"})
 	if err == nil {
 		t.Fatalf("expected error for too small file, got nil")
 	}


### PR DESCRIPTION
## Summary
- make `FinaliseUpload` return only an error
- send HTTP 204 on successful finalise
- update handler and service logic
- adjust unit, integration and e2e tests

## Testing
- `make unit-tests`
- `go test ./...` *(fails: could not start mariadb container)*
- `go test ./...` in e2e *(fails: could not start mariadb container)*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_684764ea36a4832198a1be4b403b6a15