### PR TITLE
Handle oversize image variants by copying

### DIFF
--- a/test/integration/optimise_task_test.go
+++ b/test/integration/optimise_task_test.go
@@ -96,7 +96,7 @@ func TestOptimiseTaskIntegration_SuccessPNG(t *testing.T) {
 		t.Fatalf("len(Variants) = %d; want 1", len(out.Variants))
 	}
 	v := out.Variants[0]
-	if v.Width != 100 || v.Height != 200 {
+	if v.Width != 16 || v.Height != 32 {
 		t.Errorf("variant dimensions = %dx%d; want 100x200", v.Width, v.Height)
 	}
 	exists, err := GlobalStrg.FileExists(ctx, "images", out.ObjectKey)
@@ -139,7 +139,7 @@ func TestOptimiseTaskIntegration_SuccessWEBP(t *testing.T) {
 
 	id := db.UUID(uuid.MustParse("22222222-2222-2222-2222-222222222222"))
 	objectKey := id.String() + ".webp"
-	width, height := 30, 60
+	width, height := 150, 300
 	content := testutil.GenerateWebP(t, width, height)
 	size := int64(len(content))
 	mime := "image/webp"


### PR DESCRIPTION
## Summary
- avoid upscaling when resizing images
- ensure width and height metadata updated correctly for copied variants
- add coverage for oversize variant logic and adjust unit tests

## Testing
- `make clean`
- `go test ./...`
- `go test ./test/e2e` *(fails: could not start mariadb container)*
- `go test ./test/integration` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_684876aa60f8832196c67bb31a37d24a