### PR TITLE
Add backlog optimiser service

### DIFF
--- a/internal/usecase/media/interfaces.go
+++ b/internal/usecase/media/interfaces.go
@@ -17,6 +17,7 @@ type Repository interface {
 	Create(ctx context.Context, media *model.Media) error
 	Update(ctx context.Context, media *model.Media) error
 	GetByID(ctx context.Context, ID db.UUID) (*model.Media, error)
+	ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]db.UUID, error)
 }
 
 type Storage interface {

--- a/internal/usecase/media/optimise_backlog.go
+++ b/internal/usecase/media/optimise_backlog.go
@@ -1,0 +1,39 @@
+package media
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// BacklogOptimiser triggers optimisation for stale medias.
+type BacklogOptimiser interface {
+	OptimiseBacklog(ctx context.Context) error
+}
+
+type backlogOptimiserSrv struct {
+	repo  Repository
+	tasks TaskDispatcher
+}
+
+// NewBacklogOptimiser constructs a BacklogOptimiser implementation.
+func NewBacklogOptimiser(repo Repository, tasks TaskDispatcher) BacklogOptimiser {
+	return &backlogOptimiserSrv{repo, tasks}
+}
+
+// OptimiseBacklog looks for medias older than one hour that are completed but not optimised
+// and enqueues optimisation tasks for them.
+func (s *backlogOptimiserSrv) OptimiseBacklog(ctx context.Context) error {
+	cutoff := time.Now().Add(-1 * time.Hour)
+	ids, err := s.repo.ListUnoptimisedCompletedBefore(ctx, cutoff)
+	if err != nil {
+		return err
+	}
+
+	for _, id := range ids {
+		if err := s.tasks.EnqueueOptimiseMedia(ctx, id); err != nil {
+			log.Printf("failed to enqueue optimise task for media #%s: %v", id, err)
+		}
+	}
+	return nil
+}

--- a/internal/usecase/media/optimise_backlog_test.go
+++ b/internal/usecase/media/optimise_backlog_test.go
@@ -1,0 +1,57 @@
+package media
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/google/uuid"
+)
+
+func TestBacklogOptimiser_RepoError(t *testing.T) {
+	repo := &mockRepo{listErr: errors.New("db fail")}
+	dispatcher := &mockDispatcher{}
+	svc := NewBacklogOptimiser(repo, dispatcher)
+
+	err := svc.OptimiseBacklog(context.Background())
+	if err == nil || err.Error() != "db fail" {
+		t.Fatalf("expected db fail, got %v", err)
+	}
+	if !repo.listCalled {
+		t.Error("expected list to be called")
+	}
+}
+
+func TestBacklogOptimiser_Success(t *testing.T) {
+	id1 := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id2 := db.UUID(uuid.MustParse("ffffffff-1111-2222-3333-444444444444"))
+	repo := &mockRepo{listOut: []db.UUID{id1, id2}}
+	dispatcher := &mockDispatcher{}
+	svc := NewBacklogOptimiser(repo, dispatcher)
+
+	if err := svc.OptimiseBacklog(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dispatcher.optimiseIDs) != 2 {
+		t.Fatalf("expected 2 optimise calls, got %d", len(dispatcher.optimiseIDs))
+	}
+	if dispatcher.optimiseIDs[0] != id1 || dispatcher.optimiseIDs[1] != id2 {
+		t.Errorf("optimise IDs mismatch: %+v", dispatcher.optimiseIDs)
+	}
+}
+
+func TestBacklogOptimiser_DispatcherError(t *testing.T) {
+	id1 := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id2 := db.UUID(uuid.MustParse("ffffffff-1111-2222-3333-444444444444"))
+	repo := &mockRepo{listOut: []db.UUID{id1, id2}}
+	dispatcher := &mockDispatcher{optimiseErr: errors.New("queue fail")}
+	svc := NewBacklogOptimiser(repo, dispatcher)
+
+	if err := svc.OptimiseBacklog(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dispatcher.optimiseIDs) != 2 {
+		t.Fatalf("expected 2 optimise calls, got %d", len(dispatcher.optimiseIDs))
+	}
+}


### PR DESCRIPTION
## Summary
- add `BacklogOptimiser` service to enqueue optimisation for stale medias
- support listing stale medias in repository and mocks
- update dispatcher mock to track multiple optimisation IDs
- use fixed UUIDs in backlog optimiser tests

## Testing
- `make clean`
- `make test` *(functional tests fail due to missing Docker)*


------
https://chatgpt.com/codex/tasks/task_e_68487291de8c83218b9317e04227ec9f