### PR TITLE
Add backlog optimisation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Currently accepts PNG | JPG | WEBP | PDF | MD.
 
 ### Async optimisations
 
-After step 3 the service enqueues optimisation tasks handled by the worker (requires Redis):
+ After step 3 the service enqueues optimisation tasks handled by the worker (requires Redis):
 
 - The original file is compressed (images become lossy ``.webp``; PDFs are stripped, etc.).
 - If the resulting file is an image, resized variants are created for the sizes in ``IMAGES_SIZES``.
+- When a size in ``IMAGES_SIZES`` exceeds the original width, that variant is generated as an untouched copy so the image is never stretched.
 - These operations run in the background so the original file remains available immediately after finalisation.
   While processing, ``optimised`` in ``GET /medias/{id}`` stays ``false`` and ``variants`` is empty. Once compression and resizing finish, ``optimised`` becomes ``true`` and image variants are listed.
 
@@ -65,6 +66,7 @@ After step 3 the service enqueues optimisation tasks handled by the worker (requ
 
 - run the server with ``go run ./cmd/api/``
 - start the worker with ``go run ./cmd/worker/`` *(requires Redis)*
+- run database migrations with ``go run ./cmd/migrate/``
 - run the backlog optimiser with ``go run ./cmd/optimise-backlog/`` *(requires Redis)*
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Currently accepts PNG | JPG | WEBP | PDF | MD.
 - run ``docker-compose up -d``
 - run migrations with ``go run ./cmd/migrate/``
 - run the server with ``go run ./cmd/api/``
-- run the backlog optimiser with ``go run ./cmd/optimise-backlog/`` *(requires Redis)*
 
 ## Notes
 
@@ -61,6 +60,12 @@ After step 3 the service enqueues optimisation tasks handled by the worker (requ
 - If the resulting file is an image, resized variants are created for the sizes in ``IMAGES_SIZES``.
 - These operations run in the background so the original file remains available immediately after finalisation.
   While processing, ``optimised`` in ``GET /medias/{id}`` stays ``false`` and ``variants`` is empty. Once compression and resizing finish, ``optimised`` becomes ``true`` and image variants are listed.
+
+## Manual commands
+
+- run the server with ``go run ./cmd/api/``
+- start the worker with ``go run ./cmd/worker/`` *(requires Redis)*
+- run the backlog optimiser with ``go run ./cmd/optimise-backlog/`` *(requires Redis)*
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Currently accepts PNG | JPG | WEBP | PDF | MD.
 - run ``docker-compose up -d``
 - run migrations with ``go run ./cmd/migrate/``
 - run the server with ``go run ./cmd/api/``
+- run the backlog optimiser with ``go run ./cmd/optimise-backlog/`` *(requires Redis)*
 
 ## Notes
 

--- a/cmd/optimise-backlog/main.go
+++ b/cmd/optimise-backlog/main.go
@@ -51,8 +51,7 @@ func initDb(cfg *config.Settings) *db.Database {
 
 func initDispatcher(cfg *config.Settings) mediaSvc.TaskDispatcher {
 	if cfg.RedisAddr == "" {
-		log.Println("⚠️  Redis not configured — optimisation tasks won't be enqueued")
-		return task.NewNoopDispatcher()
+		log.Fatalf("❌  Redis not configured: this command requires a running Redis instance")
 	}
 	return task.NewDispatcher(cfg.RedisAddr, cfg.RedisPassword)
 }

--- a/cmd/optimise-backlog/main.go
+++ b/cmd/optimise-backlog/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/fhuszti/medias-ms-go/internal/config"
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
+	"github.com/fhuszti/medias-ms-go/internal/task"
+	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("❌  Configuration error: %v", err)
+	}
+
+	database := initDb(cfg)
+	defer func() {
+		if err := database.Close(); err != nil {
+			log.Printf("DB close error: %v", err)
+		}
+	}()
+
+	dispatcher := initDispatcher(cfg)
+	repo := mariadb.NewMediaRepository(database.DB)
+
+	optimiser := mediaSvc.NewBacklogOptimiser(repo, dispatcher)
+	if err := optimiser.OptimiseBacklog(context.Background()); err != nil {
+		log.Fatalf("❌  Backlog optimisation failed: %v", err)
+	}
+	log.Println("✅  Backlog optimisation completed")
+}
+
+func initDb(cfg *config.Settings) *db.Database {
+	log.Println("initialising database...")
+	dbCfg := db.MariaDbConfig{
+		DSN:             cfg.MariaDBDSN,
+		MaxOpenConns:    cfg.MaxOpenConns,
+		MaxIdleConns:    cfg.MaxIdleConns,
+		ConnMaxLifetime: cfg.ConnMaxLifetime,
+	}
+	database, err := db.NewFromConfig(dbCfg)
+	if err != nil {
+		log.Fatalf("❌  Failed to connect to db: %v", err)
+	}
+	return database
+}
+
+func initDispatcher(cfg *config.Settings) mediaSvc.TaskDispatcher {
+	if cfg.RedisAddr == "" {
+		log.Println("⚠️  Redis not configured — optimisation tasks won't be enqueued")
+		return task.NewNoopDispatcher()
+	}
+	return task.NewDispatcher(cfg.RedisAddr, cfg.RedisPassword)
+}


### PR DESCRIPTION
## Summary
- add `optimise-backlog` command for manual optimisation of stale media

## Testing
- `make test` *(fails: could not start MariaDB container)*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_6848bb075f9c8321bd7c1adb4c4b7bdb