### PR TITLE
Update image variant tests for multiple widths

### DIFF
--- a/test/e2e/upload_pdf_test.go
+++ b/test/e2e/upload_pdf_test.go
@@ -179,14 +179,16 @@ func TestUploadImageE2E(t *testing.T) {
 		t.Fatalf("Variants length = %d; want 2", len(getOut.Variants))
 	}
 	var found50, found300 bool
+	key50 := fmt.Sprintf("variants/%s/%s_50.webp", out1.ID, out1.ID)
+	key300 := fmt.Sprintf("variants/%s/%s_300.webp", out1.ID, out1.ID)
 	for _, v := range getOut.Variants {
-		if v.Width == 50 {
-			if v.Height != 37 {
-				t.Errorf("variant 50 height = %d; want 37", v.Height)
+		if strings.Contains(v.URL, key50) {
+			if v.Width != 50 || v.Height != 37 {
+				t.Errorf("variant 50 dims = %dx%d; want 50x37", v.Width, v.Height)
 			}
 			found50 = true
-		} else if v.Width == 200 {
-			if v.Height != 150 {
+		} else if strings.Contains(v.URL, key300) {
+			if v.Width != 200 || v.Height != 150 {
 				t.Errorf("variant 300 dims = %dx%d; want 200x150", v.Width, v.Height)
 			}
 			found300 = true
@@ -200,8 +202,11 @@ func TestUploadImageE2E(t *testing.T) {
 			t.Errorf("variant size = %d; want >0", v.SizeBytes)
 		}
 	}
-	if !found50 || !found300 {
-		t.Error("expected variants for widths 50 and 300")
+	if !found50 {
+		t.Error("expected 50px variant")
+	}
+	if !found300 {
+		t.Error("expected 300px variant")
 	}
 }
 

--- a/test/integration/optimise_task_test.go
+++ b/test/integration/optimise_task_test.go
@@ -109,8 +109,11 @@ func TestOptimiseTaskIntegration_SuccessPNG(t *testing.T) {
 			found300 = true
 		}
 	}
-	if !found50 || !found300 {
-		t.Error("expected variants for widths 50 and 300")
+	if !found50 {
+		t.Error("expected 50px variant")
+	}
+	if !found300 {
+		t.Error("expected 300px variant")
 	}
 	exists, err := GlobalStrg.FileExists(ctx, "images", out.ObjectKey)
 	if err != nil || !exists {
@@ -198,8 +201,11 @@ func TestOptimiseTaskIntegration_SuccessWEBP(t *testing.T) {
 			found300 = true
 		}
 	}
-	if !found50 || !found300 {
-		t.Error("expected variants for widths 50 and 300")
+	if !found50 {
+		t.Error("expected 50px variant")
+	}
+	if !found300 {
+		t.Error("expected 300px variant")
 	}
 	vKey1 := fmt.Sprintf("variants/%s/%s_50.webp", id, id)
 	exists, err := GlobalStrg.FileExists(ctx, "images", vKey1)

--- a/test/testutil/worker.go
+++ b/test/testutil/worker.go
@@ -36,7 +36,7 @@ func StartWorker(dbConn *db.Database, strg *storage.Strg, redisAddr string) func
 		if err != nil {
 			return err
 		}
-		return workerHandler.ResizeImageHandler(ctx, p, []int{100}, resizeSvc)
+		return workerHandler.ResizeImageHandler(ctx, p, []int{50, 300}, resizeSvc)
 	})
 
 	srv := asynq.NewServer(asynq.RedisClientOpt{Addr: redisAddr}, asynq.Config{Concurrency: 5})


### PR DESCRIPTION
## Summary
- update worker test helper to create 50px and 300px image variants
- adjust optimisation integration tests for new widths
- check both resized and original-size variants in e2e image upload test

## Testing
- `golangci-lint run`
- `go test ./...`
- `go test ./...` *(integration tests)*
- `go test ./...` *(e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848bc27dc6c8321915bf2e5b5644cf1