### PR TITLE
Add backlog optimisation start logs

### DIFF
--- a/internal/usecase/media/optimise_backlog.go
+++ b/internal/usecase/media/optimise_backlog.go
@@ -31,6 +31,7 @@ func (s *backlogOptimiserSrv) OptimiseBacklog(ctx context.Context) error {
 	}
 
 	for _, id := range ids {
+		log.Printf("starting optimisation for media #%s", id)
 		if err := s.tasks.EnqueueOptimiseMedia(ctx, id); err != nil {
 			log.Printf("failed to enqueue optimise task for media #%s: %v", id, err)
 		}


### PR DESCRIPTION
## Summary
- log media ID each time backlog optimisation begins

## Testing
- `make test` *(fails: could not start mariadb container)*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_6848c0a0453c832198f65afa3cf9540c