### PR TITLE
Log empty optimise backlog

### DIFF
--- a/internal/usecase/media/optimise_backlog.go
+++ b/internal/usecase/media/optimise_backlog.go
@@ -30,6 +30,10 @@ func (s *backlogOptimiserSrv) OptimiseBacklog(ctx context.Context) error {
 		return err
 	}
 
+	if len(ids) == 0 {
+		log.Printf("no medias found to optimise")
+	}
+
 	for _, id := range ids {
 		log.Printf("starting optimisation for media #%s", id)
 		if err := s.tasks.EnqueueOptimiseMedia(ctx, id); err != nil {


### PR DESCRIPTION
## Summary
- add log when no medias are queued in `OptimiseBacklog`

## Testing
- `make unit-tests`
- `make clean`
- `go test ./test/e2e/...` *(fails: no Docker)*
- `go test ./test/integration/...` *(fails: no Docker)*

------
https://chatgpt.com/codex/tasks/task_e_6848c65cfe5883218343995667754e25