### PR TITLE
Add media deletion use case

### DIFF
--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -17,3 +17,5 @@ func (n *NoopCache) GetMediaDetails(ctx context.Context, id db.UUID) (*media.Get
 }
 
 func (n *NoopCache) SetMediaDetails(ctx context.Context, id db.UUID, mOut *media.GetMediaOutput) {}
+
+func (n *NoopCache) DeleteMediaDetails(ctx context.Context, id db.UUID) error { return nil }

--- a/internal/repository/mariadb/media_repository.go
+++ b/internal/repository/mariadb/media_repository.go
@@ -131,3 +131,11 @@ func (r *MediaRepository) ListUnoptimisedCompletedBefore(ctx context.Context, be
 	}
 	return ids, nil
 }
+
+func (r *MediaRepository) Delete(ctx context.Context, ID db.UUID) error {
+	log.Printf("deleting media #%s from the database...", ID)
+
+	const query = `DELETE FROM medias WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, ID)
+	return err
+}

--- a/internal/usecase/media/delete_media.go
+++ b/internal/usecase/media/delete_media.go
@@ -1,0 +1,62 @@
+package media
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+)
+
+// Deleter deletes a media and its file.
+type Deleter interface {
+	DeleteMedia(ctx context.Context, in DeleteMediaInput) error
+}
+
+type deleteMediaSrv struct {
+	repo  Repository
+	cache Cache
+	strg  Storage
+}
+
+// NewMediaDeleter constructs a Deleter implementation.
+func NewMediaDeleter(repo Repository, cache Cache, strg Storage) Deleter {
+	return &deleteMediaSrv{repo: repo, cache: cache, strg: strg}
+}
+
+// DeleteMediaInput represents the input for deleting a media.
+type DeleteMediaInput struct {
+	ID db.UUID
+}
+
+// DeleteMedia removes the file from storage, deletes DB record and clears cache.
+func (s *deleteMediaSrv) DeleteMedia(ctx context.Context, in DeleteMediaInput) error {
+	media, err := s.repo.GetByID(ctx, in.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrObjectNotFound
+		}
+		return err
+	}
+
+	for _, v := range media.Variants {
+		if err := s.strg.RemoveFile(ctx, media.Bucket, v.ObjectKey); err != nil {
+			log.Printf("failed to remove variant %q: %v", v.ObjectKey, err)
+		}
+	}
+
+	if err := s.strg.RemoveFile(ctx, media.Bucket, media.ObjectKey); err != nil {
+		return err
+	}
+
+	if err := s.repo.Delete(ctx, media.ID); err != nil {
+		return err
+	}
+
+	if err := s.cache.DeleteMediaDetails(ctx, media.ID); err != nil {
+		log.Printf("failed deleting cache for media #%s: %v", media.ID, err)
+	}
+
+	return nil
+}

--- a/internal/usecase/media/delete_media_test.go
+++ b/internal/usecase/media/delete_media_test.go
@@ -1,0 +1,75 @@
+package media
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/model"
+)
+
+func TestDeleteMedia_NotFound(t *testing.T) {
+	repo := &mockRepo{getErr: sql.ErrNoRows}
+	svc := NewMediaDeleter(repo, &mockCache{}, &mockStorage{})
+
+	err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: db.NewUUID()})
+	if !errors.Is(err, ErrObjectNotFound) {
+		t.Fatalf("expected ErrObjectNotFound, got %v", err)
+	}
+}
+
+func TestDeleteMedia_GetByIDError(t *testing.T) {
+	repo := &mockRepo{getErr: errors.New("db fail")}
+	svc := NewMediaDeleter(repo, &mockCache{}, &mockStorage{})
+
+	if err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: db.NewUUID()}); err == nil || err.Error() != "db fail" {
+		t.Fatalf("expected db fail, got %v", err)
+	}
+}
+
+func TestDeleteMedia_RemoveError(t *testing.T) {
+	m := &model.Media{ID: db.NewUUID(), Bucket: "images", ObjectKey: "k"}
+	repo := &mockRepo{mediaRecord: m}
+	strg := &mockStorage{removeErr: errors.New("remove fail")}
+	svc := NewMediaDeleter(repo, &mockCache{}, strg)
+
+	err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: m.ID})
+	if err == nil || err.Error() != "remove fail" {
+		t.Fatalf("expected remove fail, got %v", err)
+	}
+}
+
+func TestDeleteMedia_DeleteError(t *testing.T) {
+	m := &model.Media{ID: db.NewUUID(), Bucket: "images", ObjectKey: "k"}
+	repo := &mockRepo{mediaRecord: m, deleteErr: errors.New("delete fail")}
+	strg := &mockStorage{}
+	svc := NewMediaDeleter(repo, &mockCache{}, strg)
+
+	err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: m.ID})
+	if err == nil || err.Error() != "delete fail" {
+		t.Fatalf("expected delete fail, got %v", err)
+	}
+}
+
+func TestDeleteMedia_Success(t *testing.T) {
+	m := &model.Media{ID: db.NewUUID(), Bucket: "images", ObjectKey: "k", Variants: model.Variants{{ObjectKey: "v1"}}}
+	repo := &mockRepo{mediaRecord: m}
+	strg := &mockStorage{}
+	cache := &mockCache{}
+	svc := NewMediaDeleter(repo, cache, strg)
+
+	if err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: m.ID}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strg.removeCalled {
+		t.Error("expected RemoveFile to be called")
+	}
+	if !repo.deleteCalled || repo.deletedID != m.ID {
+		t.Error("expected repo.Delete to be called with ID")
+	}
+	if !cache.delMediaCalled {
+		t.Error("expected cache delete to be called")
+	}
+}

--- a/internal/usecase/media/delete_media_test.go
+++ b/internal/usecase/media/delete_media_test.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
+	"github.com/google/uuid"
 )
 
 func TestDeleteMedia_NotFound(t *testing.T) {
 	repo := &mockRepo{getErr: sql.ErrNoRows}
 	svc := NewMediaDeleter(repo, &mockCache{}, &mockStorage{})
 
-	err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: db.NewUUID()})
+	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: id})
 	if !errors.Is(err, ErrObjectNotFound) {
 		t.Fatalf("expected ErrObjectNotFound, got %v", err)
 	}
@@ -24,13 +26,14 @@ func TestDeleteMedia_GetByIDError(t *testing.T) {
 	repo := &mockRepo{getErr: errors.New("db fail")}
 	svc := NewMediaDeleter(repo, &mockCache{}, &mockStorage{})
 
-	if err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: db.NewUUID()}); err == nil || err.Error() != "db fail" {
+	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	if err := svc.DeleteMedia(context.Background(), DeleteMediaInput{ID: id}); err == nil || err.Error() != "db fail" {
 		t.Fatalf("expected db fail, got %v", err)
 	}
 }
 
 func TestDeleteMedia_RemoveError(t *testing.T) {
-	m := &model.Media{ID: db.NewUUID(), Bucket: "images", ObjectKey: "k"}
+	m := &model.Media{ID: db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k"}
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{removeErr: errors.New("remove fail")}
 	svc := NewMediaDeleter(repo, &mockCache{}, strg)
@@ -42,7 +45,7 @@ func TestDeleteMedia_RemoveError(t *testing.T) {
 }
 
 func TestDeleteMedia_DeleteError(t *testing.T) {
-	m := &model.Media{ID: db.NewUUID(), Bucket: "images", ObjectKey: "k"}
+	m := &model.Media{ID: db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k"}
 	repo := &mockRepo{mediaRecord: m, deleteErr: errors.New("delete fail")}
 	strg := &mockStorage{}
 	svc := NewMediaDeleter(repo, &mockCache{}, strg)
@@ -54,7 +57,7 @@ func TestDeleteMedia_DeleteError(t *testing.T) {
 }
 
 func TestDeleteMedia_Success(t *testing.T) {
-	m := &model.Media{ID: db.NewUUID(), Bucket: "images", ObjectKey: "k", Variants: model.Variants{{ObjectKey: "v1"}}}
+	m := &model.Media{ID: db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k", Variants: model.Variants{{ObjectKey: "v1"}}}
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{}
 	cache := &mockCache{}

--- a/internal/usecase/media/interfaces.go
+++ b/internal/usecase/media/interfaces.go
@@ -17,6 +17,7 @@ type Repository interface {
 	Create(ctx context.Context, media *model.Media) error
 	Update(ctx context.Context, media *model.Media) error
 	GetByID(ctx context.Context, ID db.UUID) (*model.Media, error)
+	Delete(ctx context.Context, ID db.UUID) error
 	ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]db.UUID, error)
 }
 
@@ -37,6 +38,7 @@ type StorageGetter func(bucket string) (Storage, error)
 type Cache interface {
 	GetMediaDetails(ctx context.Context, id db.UUID) (*GetMediaOutput, error)
 	SetMediaDetails(ctx context.Context, id db.UUID, value *GetMediaOutput)
+	DeleteMediaDetails(ctx context.Context, id db.UUID) error
 }
 
 type FileOptimiser interface {

--- a/internal/usecase/media/mocks.go
+++ b/internal/usecase/media/mocks.go
@@ -15,14 +15,17 @@ type mockRepo struct {
 	getErr     error
 	createErr  error
 	updateErr  error
+	deleteErr  error
 	listErr    error
 	listOut    []db.UUID
 	listBefore time.Time
 
-	getCalled  bool
-	created    *model.Media
-	updated    *model.Media
-	listCalled bool
+	getCalled    bool
+	created      *model.Media
+	updated      *model.Media
+	deleteCalled bool
+	deletedID    db.UUID
+	listCalled   bool
 }
 
 func (m *mockRepo) GetByID(ctx context.Context, id db.UUID) (*model.Media, error) {
@@ -39,6 +42,12 @@ func (m *mockRepo) Update(ctx context.Context, media *model.Media) error {
 func (m *mockRepo) Create(ctx context.Context, media *model.Media) error {
 	m.created = media
 	return m.createErr
+}
+
+func (m *mockRepo) Delete(ctx context.Context, id db.UUID) error {
+	m.deleteCalled = true
+	m.deletedID = id
+	return m.deleteErr
 }
 
 func (m *mockRepo) ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]db.UUID, error) {
@@ -68,6 +77,7 @@ type mockStorage struct {
 	getErr                  error
 	saveErr                 error
 	copyErr                 error
+	removeErr               error
 	fileExistsErr           error
 
 	initBucketCalled           bool
@@ -112,7 +122,7 @@ func (m *mockStorage) StatFile(ctx context.Context, bucket, fileKey string) (Fil
 }
 func (m *mockStorage) RemoveFile(ctx context.Context, bucket, fileKey string) error {
 	m.removeCalled = true
-	return nil
+	return m.removeErr
 }
 func (m *mockStorage) GetFile(ctx context.Context, bucket, fileKey string) (io.ReadSeekCloser, error) {
 	m.getCalled = true


### PR DESCRIPTION
## Summary
- add `DeleteMedia` service in usecase layer
- extend repository and cache interfaces
- implement delete in MariaDB repository
- update caches and mocks
- cover deletion logic with unit tests

## Testing
- `make unit-tests`
- `make functional-tests` *(fails: could not start mariadb container)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6849bf0b4ed883218642b6573f50f715