### PR TITLE
Implement media deletion handler

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -61,6 +61,10 @@ func main() {
 	r.With(api.WithID()).
 		Get("/medias/{id}", api.GetMediaHandler(getMediaSvc))
 
+	deleteMediaSvc := mediaSvc.NewMediaDeleter(mediaRepo, ca, strg)
+	r.With(api.WithID()).
+		Delete("/medias/{id}", api.DeleteMediaHandler(deleteMediaSvc))
+
 	listenRouter(r, cfg, database)
 }
 

--- a/internal/handler/api/delete_media.go
+++ b/internal/handler/api/delete_media.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"errors"
+	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"log"
+	"net/http"
+)
+
+// DeleteMediaHandler deletes a media by ID.
+func DeleteMediaHandler(svc media.Deleter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, ok := IDFromContext(r.Context())
+		if !ok {
+			WriteError(w, http.StatusBadRequest, "ID is required", nil)
+			return
+		}
+
+		in := media.DeleteMediaInput{ID: id}
+		if err := svc.DeleteMedia(r.Context(), in); err != nil {
+			if errors.Is(err, media.ErrObjectNotFound) {
+				WriteError(w, http.StatusNotFound, "Media not found", nil)
+				return
+			}
+			WriteError(w, http.StatusInternalServerError, "Failed to delete media", err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+		log.Printf("✅  Successfully deleted media #%s", id)
+	}
+}

--- a/internal/handler/api/delete_media_test.go
+++ b/internal/handler/api/delete_media_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	mediaUC "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	"github.com/google/uuid"
+)
+
+type mockDeleter struct {
+	in  mediaUC.DeleteMediaInput
+	err error
+}
+
+func (m *mockDeleter) DeleteMedia(ctx context.Context, in mediaUC.DeleteMediaInput) error {
+	m.in = in
+	return m.err
+}
+
+func TestDeleteMediaHandler(t *testing.T) {
+	validID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	tests := []struct {
+		name           string
+		ctxID          *db.UUID
+		svcErr         error
+		wantStatus     int
+		wantBodySubstr string
+	}{
+		{
+			name:           "missing id",
+			ctxID:          nil,
+			svcErr:         nil,
+			wantStatus:     http.StatusBadRequest,
+			wantBodySubstr: "ID is required",
+		},
+		{
+			name:           "not found",
+			ctxID:          &validID,
+			svcErr:         mediaUC.ErrObjectNotFound,
+			wantStatus:     http.StatusNotFound,
+			wantBodySubstr: "Media not found",
+		},
+		{
+			name:           "service error",
+			ctxID:          &validID,
+			svcErr:         errors.New("boom"),
+			wantStatus:     http.StatusInternalServerError,
+			wantBodySubstr: "Failed to delete media",
+		},
+		{
+			name:       "happy path",
+			ctxID:      &validID,
+			svcErr:     nil,
+			wantStatus: http.StatusNoContent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockSvc := &mockDeleter{err: tc.svcErr}
+			h := DeleteMediaHandler(mockSvc)
+
+			req := httptest.NewRequest(http.MethodDelete, "/medias/"+validID.String(), nil)
+			if tc.ctxID != nil {
+				req = req.WithContext(context.WithValue(req.Context(), IDKey, *tc.ctxID))
+			}
+
+			rec := httptest.NewRecorder()
+			h(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d; want %d", rec.Code, tc.wantStatus)
+			}
+
+			if tc.wantStatus == http.StatusNoContent {
+				if rec.Body.Len() != 0 {
+					t.Errorf("expected empty body, got %q", rec.Body.String())
+				}
+				if mockSvc.in.ID != validID {
+					t.Errorf("service got ID = %s; want %s", mockSvc.in.ID, validID)
+				}
+			} else {
+				if !errors.Is(tc.svcErr, mediaUC.ErrObjectNotFound) && tc.ctxID != nil {
+					if mockSvc.in.ID != validID {
+						t.Errorf("service got ID = %s; want %s", mockSvc.in.ID, validID)
+					}
+				}
+				if !contains(rec.Body.String(), tc.wantBodySubstr) {
+					t.Errorf("body = %q; want to contain %q", rec.Body.String(), tc.wantBodySubstr)
+				}
+			}
+		})
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return needle == "" || strings.Contains(haystack, needle)
+}


### PR DESCRIPTION
## Summary
- add DeleteMediaHandler API endpoint and tests
- register DELETE `/medias/{id}` route

## Testing
- `make unit-tests`
- `make functional-tests` *(fails: could not start mariadb container)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6849db5df2d08321b8858fef608006f3