### PR TITLE
Delete cache after optimising and resizing

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fhuszti/medias-ms-go/internal/cache"
 	"github.com/fhuszti/medias-ms-go/internal/config"
 	"github.com/fhuszti/medias-ms-go/internal/db"
 	workerHandler "github.com/fhuszti/medias-ms-go/internal/handler/worker"
@@ -41,8 +42,9 @@ func main() {
 	repo := mariadb.NewMediaRepository(database.DB)
 	fo := optimiser.NewFileOptimiser(optimiser.NewWebPEncoder(), optimiser.NewPDFOptimizer())
 	dispatcher := task.NewDispatcher(cfg.RedisAddr, cfg.RedisPassword)
-	optimiseSvc := mediaSvc.NewMediaOptimiser(repo, fo, strg, dispatcher)
-	resizeSvc := mediaSvc.NewImageResizer(repo, fo, strg)
+	ca := cache.NewCache(cfg.RedisAddr, cfg.RedisPassword)
+	optimiseSvc := mediaSvc.NewMediaOptimiser(repo, fo, strg, dispatcher, ca)
+	resizeSvc := mediaSvc.NewImageResizer(repo, fo, strg, ca)
 
 	mux := asynq.NewServeMux()
 	mux.HandleFunc(task.TypeOptimiseMedia, func(ctx context.Context, t *asynq.Task) error {

--- a/internal/usecase/media/optimise_media.go
+++ b/internal/usecase/media/optimise_media.go
@@ -22,10 +22,11 @@ type mediaOptimiserSrv struct {
 	opt   FileOptimiser
 	strg  Storage
 	tasks TaskDispatcher
+	cache Cache
 }
 
-func NewMediaOptimiser(repo Repository, opt FileOptimiser, strg Storage, tasks TaskDispatcher) Optimiser {
-	return &mediaOptimiserSrv{repo, opt, strg, tasks}
+func NewMediaOptimiser(repo Repository, opt FileOptimiser, strg Storage, tasks TaskDispatcher, cache Cache) Optimiser {
+	return &mediaOptimiserSrv{repo, opt, strg, tasks, cache}
 }
 
 type OptimiseMediaInput struct {
@@ -122,6 +123,10 @@ func (m *mediaOptimiserSrv) OptimiseMedia(ctx context.Context, in OptimiseMediaI
 		if err := m.tasks.EnqueueResizeImage(ctx, media.ID); err != nil {
 			log.Printf("failed to enqueue resize task for media #%s: %v", media.ID, err)
 		}
+	}
+
+	if err := m.cache.DeleteMediaDetails(ctx, media.ID); err != nil {
+		log.Printf("failed deleting cache for media #%s: %v", media.ID, err)
 	}
 
 	return nil

--- a/internal/usecase/media/optimise_media_test.go
+++ b/internal/usecase/media/optimise_media_test.go
@@ -28,7 +28,7 @@ func newCompletedMedia() *model.Media {
 func TestOptimiseMedia_GetByIDNotFound(t *testing.T) {
 	repo := &mockRepo{getErr: sql.ErrNoRows}
 	strg := &mockStorage{}
-	svc := NewMediaOptimiser(repo, &mockFileOptimiser{}, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, &mockFileOptimiser{}, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: db.NewUUID()})
 	if !errors.Is(err, ErrObjectNotFound) {
@@ -39,7 +39,7 @@ func TestOptimiseMedia_GetByIDNotFound(t *testing.T) {
 func TestOptimiseMedia_GetByIDError(t *testing.T) {
 	repo := &mockRepo{getErr: errors.New("db fail")}
 	strg := &mockStorage{}
-	svc := NewMediaOptimiser(repo, &mockFileOptimiser{}, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, &mockFileOptimiser{}, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: db.NewUUID()})
 	if err == nil || err.Error() != "db fail" {
@@ -52,7 +52,7 @@ func TestOptimiseMedia_WrongStatus(t *testing.T) {
 	m.Status = model.MediaStatusPending
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{}
-	svc := NewMediaOptimiser(repo, &mockFileOptimiser{}, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, &mockFileOptimiser{}, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err == nil || !strings.Contains(err.Error(), "completed") {
@@ -64,7 +64,7 @@ func TestOptimiseMedia_GetFileError(t *testing.T) {
 	m := newCompletedMedia()
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{getErr: errors.New("get fail")}
-	svc := NewMediaOptimiser(repo, &mockFileOptimiser{}, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, &mockFileOptimiser{}, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err == nil || err.Error() != "get fail" {
@@ -77,7 +77,7 @@ func TestOptimiseMedia_CompressError(t *testing.T) {
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{}
 	fo := &mockFileOptimiser{compressErr: errors.New("compress fail")}
-	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err == nil || err.Error() != "compress fail" {
@@ -90,7 +90,7 @@ func TestOptimiseMedia_ExtensionError(t *testing.T) {
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{}
 	fo := &mockFileOptimiser{mimeOut: "application/unknown"}
-	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err == nil || !strings.Contains(err.Error(), "unsupported mime type") {
@@ -103,7 +103,7 @@ func TestOptimiseMedia_SaveFileError(t *testing.T) {
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{saveErr: errors.New("save fail")}
 	fo := &mockFileOptimiser{mimeOut: *m.MimeType}
-	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err == nil || !strings.Contains(err.Error(), "save fail") {
@@ -116,7 +116,7 @@ func TestOptimiseMedia_CopyFileError(t *testing.T) {
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{copyErr: errors.New("copy fail")}
 	fo := &mockFileOptimiser{mimeOut: *m.MimeType}
-	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err == nil || !strings.Contains(err.Error(), "copy fail") {
@@ -129,7 +129,7 @@ func TestOptimiseMedia_StatError(t *testing.T) {
 	repo := &mockRepo{mediaRecord: m}
 	strg := &mockStorage{statErr: errors.New("stat fail")}
 	fo := &mockFileOptimiser{mimeOut: *m.MimeType}
-	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err == nil || !strings.Contains(err.Error(), "stat fail") {
@@ -143,7 +143,7 @@ func TestOptimiseMedia_UpdateError(t *testing.T) {
 	strg := &mockStorage{}
 	strg.statInfo = FileInfo{SizeBytes: 200}
 	fo := &mockFileOptimiser{mimeOut: *m.MimeType}
-	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{})
+	svc := NewMediaOptimiser(repo, fo, strg, &mockDispatcher{}, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err == nil || !strings.Contains(err.Error(), "update fail") {
@@ -158,7 +158,7 @@ func TestOptimiseMedia_SuccessSameMime(t *testing.T) {
 	strg.statInfo = FileInfo{SizeBytes: 456}
 	fo := &mockFileOptimiser{mimeOut: *m.MimeType, compressOut: []byte("comp")}
 	dispatcher := &mockDispatcher{}
-	svc := NewMediaOptimiser(repo, fo, strg, dispatcher)
+	svc := NewMediaOptimiser(repo, fo, strg, dispatcher, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err != nil {
@@ -189,7 +189,7 @@ func TestOptimiseMedia_SuccessMimeChange(t *testing.T) {
 	strg.statInfo = FileInfo{SizeBytes: 789}
 	fo := &mockFileOptimiser{mimeOut: "image/webp", compressOut: []byte("webp")}
 	dispatcher := &mockDispatcher{}
-	svc := NewMediaOptimiser(repo, fo, strg, dispatcher)
+	svc := NewMediaOptimiser(repo, fo, strg, dispatcher, &mockCache{})
 
 	err := svc.OptimiseMedia(context.Background(), OptimiseMediaInput{ID: m.ID})
 	if err != nil {

--- a/internal/usecase/media/resize_image.go
+++ b/internal/usecase/media/resize_image.go
@@ -19,14 +19,15 @@ type ImageResizer interface {
 }
 
 type imageResizerSrv struct {
-	repo Repository
-	opt  FileOptimiser
-	strg Storage
+	repo  Repository
+	opt   FileOptimiser
+	strg  Storage
+	cache Cache
 }
 
 // NewImageResizer constructs an ImageResizer implementation.
-func NewImageResizer(repo Repository, opt FileOptimiser, strg Storage) ImageResizer {
-	return &imageResizerSrv{repo, opt, strg}
+func NewImageResizer(repo Repository, opt FileOptimiser, strg Storage, cache Cache) ImageResizer {
+	return &imageResizerSrv{repo, opt, strg, cache}
 }
 
 // ResizeImageInput represents the input for creating resized variants.
@@ -117,6 +118,10 @@ func (s *imageResizerSrv) ResizeImage(ctx context.Context, in ResizeImageInput) 
 	if err := s.repo.Update(ctx, media); err != nil {
 		log.Printf("failed updating media with variants: %v", err)
 		return fmt.Errorf("failed updating media: %w", err)
+	}
+
+	if err := s.cache.DeleteMediaDetails(ctx, media.ID); err != nil {
+		log.Printf("failed deleting cache for media #%s: %v", media.ID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- clear cached media details after optimisation
- clear cached media details after resizing
- wire cache into worker and test worker
- adapt unit tests to updated constructors

## Testing
- `golangci-lint run`
- `go test ./...`
- `cd test/e2e && go test ./...` *(fails: could not start mariadb container)*
- `cd test/integration && go test ./...` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_6851cebb6e3c83218173fc9a575261ed