### PR TITLE
Add resize step to backlog optimiser

### DIFF
--- a/internal/usecase/media/interfaces.go
+++ b/internal/usecase/media/interfaces.go
@@ -19,6 +19,7 @@ type Repository interface {
 	GetByID(ctx context.Context, ID db.UUID) (*model.Media, error)
 	Delete(ctx context.Context, ID db.UUID) error
 	ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]db.UUID, error)
+	ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]db.UUID, error)
 }
 
 type Storage interface {

--- a/internal/usecase/media/mocks.go
+++ b/internal/usecase/media/mocks.go
@@ -20,6 +20,12 @@ type mockRepo struct {
 	listOut    []db.UUID
 	listBefore time.Time
 
+	listVariantsErr    error
+	listVariantsOut    []db.UUID
+	listVariantsBefore time.Time
+
+	listVariantsCalled bool
+
 	getCalled    bool
 	created      *model.Media
 	updated      *model.Media
@@ -57,6 +63,15 @@ func (m *mockRepo) ListUnoptimisedCompletedBefore(ctx context.Context, before ti
 		return nil, m.listErr
 	}
 	return m.listOut, nil
+}
+
+func (m *mockRepo) ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]db.UUID, error) {
+	m.listVariantsCalled = true
+	m.listVariantsBefore = before
+	if m.listVariantsErr != nil {
+		return nil, m.listVariantsErr
+	}
+	return m.listVariantsOut, nil
 }
 
 type nopRSC struct{ io.ReadSeeker }
@@ -211,7 +226,7 @@ type mockDispatcher struct {
 	optimiseErr    error
 
 	resizeCalled bool
-	resizeID     db.UUID
+	resizeIDs    []db.UUID
 	resizeErr    error
 }
 
@@ -223,6 +238,6 @@ func (m *mockDispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) e
 
 func (m *mockDispatcher) EnqueueResizeImage(ctx context.Context, id db.UUID) error {
 	m.resizeCalled = true
-	m.resizeID = id
+	m.resizeIDs = append(m.resizeIDs, id)
 	return m.resizeErr
 }

--- a/internal/usecase/media/optimise_backlog.go
+++ b/internal/usecase/media/optimise_backlog.go
@@ -40,5 +40,21 @@ func (s *backlogOptimiserSrv) OptimiseBacklog(ctx context.Context) error {
 			log.Printf("failed to enqueue optimise task for media #%s: %v", id, err)
 		}
 	}
+
+	resizeIDs, err := s.repo.ListOptimisedImagesNoVariantsBefore(ctx, cutoff)
+	if err != nil {
+		return err
+	}
+
+	if len(resizeIDs) == 0 {
+		log.Printf("no images found to resize")
+	}
+
+	for _, id := range resizeIDs {
+		log.Printf("starting resize for media #%s", id)
+		if err := s.tasks.EnqueueResizeImage(ctx, id); err != nil {
+			log.Printf("failed to enqueue resize task for media #%s: %v", id, err)
+		}
+	}
 	return nil
 }

--- a/internal/usecase/media/optimise_backlog_test.go
+++ b/internal/usecase/media/optimise_backlog_test.go
@@ -26,7 +26,9 @@ func TestBacklogOptimiser_RepoError(t *testing.T) {
 func TestBacklogOptimiser_Success(t *testing.T) {
 	id1 := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	id2 := db.UUID(uuid.MustParse("ffffffff-1111-2222-3333-444444444444"))
-	repo := &mockRepo{listOut: []db.UUID{id1, id2}}
+	resize1 := db.UUID(uuid.MustParse("11111111-2222-3333-4444-555555555555"))
+	resize2 := db.UUID(uuid.MustParse("66666666-7777-8888-9999-000000000000"))
+	repo := &mockRepo{listOut: []db.UUID{id1, id2}, listVariantsOut: []db.UUID{resize1, resize2}}
 	dispatcher := &mockDispatcher{}
 	svc := NewBacklogOptimiser(repo, dispatcher)
 
@@ -38,6 +40,15 @@ func TestBacklogOptimiser_Success(t *testing.T) {
 	}
 	if dispatcher.optimiseIDs[0] != id1 || dispatcher.optimiseIDs[1] != id2 {
 		t.Errorf("optimise IDs mismatch: %+v", dispatcher.optimiseIDs)
+	}
+	if len(dispatcher.resizeIDs) != 2 {
+		t.Fatalf("expected 2 resize calls, got %d", len(dispatcher.resizeIDs))
+	}
+	if dispatcher.resizeIDs[0] != resize1 || dispatcher.resizeIDs[1] != resize2 {
+		t.Errorf("resize IDs mismatch: %+v", dispatcher.resizeIDs)
+	}
+	if !repo.listVariantsCalled {
+		t.Error("expected list variants to be called")
 	}
 }
 
@@ -53,5 +64,33 @@ func TestBacklogOptimiser_DispatcherError(t *testing.T) {
 	}
 	if len(dispatcher.optimiseIDs) != 2 {
 		t.Fatalf("expected 2 optimise calls, got %d", len(dispatcher.optimiseIDs))
+	}
+}
+
+func TestBacklogOptimiser_ListVariantsError(t *testing.T) {
+	repo := &mockRepo{listVariantsErr: errors.New("variants fail")}
+	dispatcher := &mockDispatcher{}
+	svc := NewBacklogOptimiser(repo, dispatcher)
+
+	err := svc.OptimiseBacklog(context.Background())
+	if err == nil || err.Error() != "variants fail" {
+		t.Fatalf("expected variants fail, got %v", err)
+	}
+	if !repo.listVariantsCalled {
+		t.Error("expected list variants to be called")
+	}
+}
+
+func TestBacklogOptimiser_ResizeDispatcherError(t *testing.T) {
+	resize1 := db.UUID(uuid.MustParse("11111111-2222-3333-4444-555555555555"))
+	repo := &mockRepo{listVariantsOut: []db.UUID{resize1}}
+	dispatcher := &mockDispatcher{resizeErr: errors.New("queue fail")}
+	svc := NewBacklogOptimiser(repo, dispatcher)
+
+	if err := svc.OptimiseBacklog(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dispatcher.resizeIDs) != 1 {
+		t.Fatalf("expected 1 resize call, got %d", len(dispatcher.resizeIDs))
 	}
 }

--- a/internal/usecase/media/optimise_media_test.go
+++ b/internal/usecase/media/optimise_media_test.go
@@ -177,7 +177,7 @@ func TestOptimiseMedia_SuccessSameMime(t *testing.T) {
 	if !strg.saveCalled || !strg.copyCalled || !strg.removeCalled || !strg.getCalled || !strg.statCalled {
 		t.Error("storage methods not fully called")
 	}
-	if !dispatcher.resizeCalled || dispatcher.resizeID != m.ID {
+	if !dispatcher.resizeCalled || len(dispatcher.resizeIDs) != 1 || dispatcher.resizeIDs[0] != m.ID {
 		t.Error("resize task not enqueued")
 	}
 }
@@ -204,7 +204,7 @@ func TestOptimiseMedia_SuccessMimeChange(t *testing.T) {
 	if !strg.saveCalled || !strg.copyCalled {
 		t.Error("expected save and copy calls")
 	}
-	if !dispatcher.resizeCalled || dispatcher.resizeID != m.ID {
+	if !dispatcher.resizeCalled || len(dispatcher.resizeIDs) != 1 || dispatcher.resizeIDs[0] != m.ID {
 		t.Error("resize task not enqueued")
 	}
 }


### PR DESCRIPTION
## Summary
- add `ListOptimisedImagesNoVariantsBefore` repository method
- optimise backlog now enqueues resize tasks for old images lacking variants
- extend mocks and tests for new functionality

## Testing
- `go test ./...`
- `cd test/e2e && go test ./...` *(fails: could not start mariadb container)*
- `cd ../integration && go test ./...` *(fails: could not start mariadb container)*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_6851d3f5c1508321b82916ca3bd8632a