### PR TITLE
Remove unused bucket middleware

### DIFF
--- a/internal/handler/api/context_keys.go
+++ b/internal/handler/api/context_keys.go
@@ -7,13 +7,7 @@ import (
 
 type ctxKey string
 
-const DestBucketKey ctxKey = "destBucket"
 const IDKey ctxKey = "id"
-
-func BucketFromContext(ctx context.Context) (string, bool) {
-	b, ok := ctx.Value(DestBucketKey).(string)
-	return b, ok
-}
 
 func IDFromContext(ctx context.Context) (db.UUID, bool) {
 	id, ok := ctx.Value(IDKey).(db.UUID)

--- a/internal/handler/api/middleware.go
+++ b/internal/handler/api/middleware.go
@@ -13,32 +13,6 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-func WithDestBucket(allowed []string) func(http.Handler) http.Handler {
-	// turn the slice into a map for fast lookup
-	m := make(map[string]struct{}, len(allowed))
-	for _, b := range allowed {
-		m[b] = struct{}{}
-	}
-
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			bucket := chi.URLParam(r, "destBucket")
-			if bucket == "" {
-				WriteError(w, http.StatusBadRequest, "destination bucket is required", nil)
-				return
-			}
-			if _, ok := m[bucket]; !ok {
-				WriteError(w, http.StatusBadRequest, fmt.Sprintf("destination bucket %q does not exist", bucket), nil)
-				return
-			}
-
-			// stash it in context and call the real handler
-			ctx := context.WithValue(r.Context(), DestBucketKey, bucket)
-			next.ServeHTTP(w, r.WithContext(ctx))
-		})
-	}
-}
-
 func WithID() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/handler/api/middleware_test.go
+++ b/internal/handler/api/middleware_test.go
@@ -14,65 +14,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-func TestWithDestBucketMiddleware(t *testing.T) {
-	allowed := []string{"staging", "images"}
-	mw := WithDestBucket(allowed)
-
-	tests := []struct {
-		name           string
-		paramValue     string // what chi.URLParam(r, "destBucket") returns
-		wantStatus     int
-		expectNextCall bool // if the next handler should run
-	}{
-		{"missing param", "", http.StatusBadRequest, false},
-		{"forbidden bucket", "other", http.StatusBadRequest, false},
-		{"allowed staging", "staging", http.StatusNoContent, true},
-		{"allowed images", "images", http.StatusNoContent, true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// dummy handler that records if it's called
-			nextCalled := false
-			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				nextCalled = true
-				// echo back the bucket from context
-				if b, ok := BucketFromContext(r.Context()); ok {
-					w.Header().Set("X-Bucket", b)
-				}
-				w.WriteHeader(http.StatusNoContent)
-			})
-
-			req := httptest.NewRequest("GET", "/any", nil)
-			// inject chi URLParam
-			rctx := chi.NewRouteContext()
-			if tc.paramValue != "" {
-				rctx.URLParams.Add("destBucket", tc.paramValue)
-			}
-			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-
-			rec := httptest.NewRecorder()
-
-			// call middleware
-			handler := mw(next)
-			handler.ServeHTTP(rec, req)
-
-			if rec.Code != tc.wantStatus {
-				t.Errorf("status = %d; want %d", rec.Code, tc.wantStatus)
-			}
-			if nextCalled != tc.expectNextCall {
-				t.Errorf("nextCalled = %v; want %v", nextCalled, tc.expectNextCall)
-			}
-			if tc.expectNextCall {
-				got := rec.Header().Get("X-Bucket")
-				if got != tc.paramValue {
-					t.Errorf("bucket in context = %q; want %q", got, tc.paramValue)
-				}
-			}
-		})
-	}
-}
-
 func TestWithIDMiddleware(t *testing.T) {
 	mw := WithID()
 


### PR DESCRIPTION
## Summary
- delete unused WithDestBucket middleware and its test
- drop context helper and constant for destination bucket

## Testing
- `make clean`
- `make test` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_6851e91dbd1883218d4541f7eea8a235