### PR TITLE
Add 404 for finalise_upload

### DIFF
--- a/internal/handler/api/finalise_upload.go
+++ b/internal/handler/api/finalise_upload.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/fhuszti/medias-ms-go/internal/validation"
@@ -53,6 +54,10 @@ func FinaliseUploadHandler(svc media.UploadFinaliser, allowedBuckets []string) h
 			DestBucket: req.DestBucket,
 		}
 		if err := svc.FinaliseUpload(r.Context(), input); err != nil {
+			if errors.Is(err, media.ErrObjectNotFound) {
+				WriteError(w, http.StatusNotFound, "Media not found", nil)
+				return
+			}
 			WriteError(w, http.StatusInternalServerError, fmt.Sprintf("could not finalise upload of media #%s", input.ID), err)
 			return
 		}

--- a/internal/usecase/media/finalise_upload.go
+++ b/internal/usecase/media/finalise_upload.go
@@ -3,6 +3,7 @@ package media
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	_ "golang.org/x/image/webp"
@@ -41,6 +42,9 @@ type FinaliseUploadInput struct {
 func (s *uploadFinaliserSrv) FinaliseUpload(ctx context.Context, in FinaliseUploadInput) error {
 	media, err := s.repo.GetByID(ctx, in.ID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrObjectNotFound
+		}
 		return err
 	}
 	if media.Status == model.MediaStatusCompleted {


### PR DESCRIPTION
## Summary
- handle missing records for FinaliseUpload and return ErrObjectNotFound
- map ErrObjectNotFound to HTTP 404 in FinaliseUploadHandler

## Testing
- `make clean`
- `make test` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_6851e93f1d28832194c5d215970a8182