### PR TITLE
Update cache key prefix

### DIFF
--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -8,6 +8,9 @@ import (
 
 type NoopCache struct{}
 
+// compile-time check: *NoopCache must satisfy media.Cache
+var _ media.Cache = (*NoopCache)(nil)
+
 func NewNoop() *NoopCache {
 	return &NoopCache{}
 }


### PR DESCRIPTION
## Summary
- support etag prefixing in cache keys
- cover optional flag with tests
- ensure noop cache implements interface

## Testing
- `go test ./...`
- `cd test/e2e/ && go test ./...` *(fails: could not start mariadb container)*
- `cd test/integration/ && go test ./...` *(fails: could not start mariadb container)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_685b3056382c832182562172c8a107be