### PR TITLE
Split cache set

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"log"
 	"time"
 
@@ -69,8 +68,12 @@ func (c *Cache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte, va
 	if err := c.client.Set(ctx, getCacheKey(id.String(), false), data, exp).Err(); err != nil {
 		log.Printf("WARNING: redis set failed: %v", err)
 	}
+}
 
-	etag := fmt.Sprintf("%08x", crc32.ChecksumIEEE(data))
+func (c *Cache) SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time) {
+	log.Printf("creating etag in cache for media #%s, valid until %s...", id, validUntil.Format(time.RFC1123))
+	exp := time.Until(validUntil)
+
 	if err := c.client.Set(ctx, getCacheKey(id.String(), true), etag, exp).Err(); err != nil {
 		log.Printf("WARNING: redis set failed: %v", err)
 	}

--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -28,4 +28,7 @@ func (n *NoopCache) GetEtagMediaDetails(ctx context.Context, id db.UUID) (string
 func (n *NoopCache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte, validUntil time.Time) {
 }
 
+func (n *NoopCache) SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time) {
+}
+
 func (n *NoopCache) DeleteMediaDetails(ctx context.Context, id db.UUID) error { return nil }

--- a/internal/mock/cache.go
+++ b/internal/mock/cache.go
@@ -36,6 +36,9 @@ func (c *MockCache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte
 	c.Data = data
 }
 
+func (c *MockCache) SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time) {
+}
+
 func (c *MockCache) DeleteMediaDetails(ctx context.Context, id db.UUID) error {
 	c.DelMediaCalled = true
 	return c.DelMediaErr

--- a/internal/port/cache.go
+++ b/internal/port/cache.go
@@ -12,5 +12,6 @@ type Cache interface {
 	GetMediaDetails(ctx context.Context, id db.UUID) ([]byte, error)
 	GetEtagMediaDetails(ctx context.Context, id db.UUID) (string, error)
 	SetMediaDetails(ctx context.Context, id db.UUID, data []byte, validUntil time.Time)
+	SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time)
 	DeleteMediaDetails(ctx context.Context, id db.UUID) error
 }


### PR DESCRIPTION
## Summary
- add SetEtagMediaDetails to cache interface and implementations
- update cache tests for new setter

## Testing
- `go test ./...`
- `cd test/e2e && go test ./...` *(fails: dial unix /var/run/docker.sock: connect: no such file or directory)*
- `cd test/integration && go test ./...` *(fails: dial unix /var/run/docker.sock: connect: no such file or directory)*
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68646f637c78832190b23b61e6e5614f