### PR TITLE
Clear etag cache on media changes

### DIFF
--- a/internal/usecase/media/delete_media.go
+++ b/internal/usecase/media/delete_media.go
@@ -58,6 +58,9 @@ func (s *deleteMediaSrv) DeleteMedia(ctx context.Context, in DeleteMediaInput) e
 	if err := s.cache.DeleteMediaDetails(ctx, media.ID); err != nil {
 		log.Printf("failed deleting cache for media #%s: %v", media.ID, err)
 	}
+	if err := s.cache.DeleteEtagMediaDetails(ctx, media.ID); err != nil {
+		log.Printf("failed deleting etag cache for media #%s: %v", media.ID, err)
+	}
 
 	return nil
 }

--- a/internal/usecase/media/delete_media_test.go
+++ b/internal/usecase/media/delete_media_test.go
@@ -76,4 +76,7 @@ func TestDeleteMedia_Success(t *testing.T) {
 	if !cache.DelMediaCalled {
 		t.Error("expected cache delete to be called")
 	}
+	if !cache.DelEtagCalled {
+		t.Error("expected etag cache delete to be called")
+	}
 }

--- a/internal/usecase/media/optimise_media.go
+++ b/internal/usecase/media/optimise_media.go
@@ -130,6 +130,9 @@ func (m *mediaOptimiserSrv) OptimiseMedia(ctx context.Context, in OptimiseMediaI
 	if err := m.cache.DeleteMediaDetails(ctx, media.ID); err != nil {
 		log.Printf("failed deleting cache for media #%s: %v", media.ID, err)
 	}
+	if err := m.cache.DeleteEtagMediaDetails(ctx, media.ID); err != nil {
+		log.Printf("failed deleting etag cache for media #%s: %v", media.ID, err)
+	}
 
 	return nil
 }

--- a/internal/usecase/media/resize_image.go
+++ b/internal/usecase/media/resize_image.go
@@ -125,5 +125,8 @@ func (s *imageResizerSrv) ResizeImage(ctx context.Context, in ResizeImageInput) 
 	if err := s.cache.DeleteMediaDetails(ctx, media.ID); err != nil {
 		log.Printf("failed deleting cache for media #%s: %v", media.ID, err)
 	}
+	if err := s.cache.DeleteEtagMediaDetails(ctx, media.ID); err != nil {
+		log.Printf("failed deleting etag cache for media #%s: %v", media.ID, err)
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- clear ETag cache entries whenever media cache entries are removed
- assert that the ETag cache deletion occurs when deleting a media

## Testing
- `make test` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_686477ab39a083218955894b5bf9cd82