### PR TITLE
Inject media getter into renderer

### DIFF
--- a/internal/renderer/http_renderer.go
+++ b/internal/renderer/http_renderer.go
@@ -17,33 +17,30 @@ import (
 type HTTPRenderer interface {
 	// RenderGetMedia returns the cached JSON result and its ETag if available or
 	// executes the underlying use case and caches the output otherwise.
-	RenderGetMedia(ctx context.Context, id db.UUID) ([]byte, string, error)
+	RenderGetMedia(ctx context.Context, getter media.Getter, id db.UUID) ([]byte, string, error)
 }
 
 type httpRenderer struct {
 	cache port.Cache
-	repo  port.MediaRepository
-	strg  port.Storage
 }
 
 // compile-time check: *httpRenderer must satisfy HTTPRenderer
 var _ HTTPRenderer = (*httpRenderer)(nil)
 
 // NewHTTPRenderer creates a new HTTPRenderer implementation.
-func NewHTTPRenderer(cache port.Cache, repo port.MediaRepository, strg port.Storage) HTTPRenderer {
-	return &httpRenderer{cache: cache, repo: repo, strg: strg}
+func NewHTTPRenderer(cache port.Cache) HTTPRenderer {
+	return &httpRenderer{cache: cache}
 }
 
 // RenderGetMedia fetches media details either from cache or from the wrapped use
 // case. It returns the JSON encoded output and a quoted ETag string.
-func (r *httpRenderer) RenderGetMedia(ctx context.Context, id db.UUID) ([]byte, string, error) {
+func (r *httpRenderer) RenderGetMedia(ctx context.Context, getter media.Getter, id db.UUID) ([]byte, string, error) {
 	raw, err := r.cache.GetMediaDetails(ctx, id)
 	etag, errEtag := r.cache.GetEtagMediaDetails(ctx, id)
 	if err == nil && errEtag == nil && raw != nil && etag != "" {
 		return raw, etag, nil
 	}
 
-	getter := media.NewMediaGetter(r.repo, r.strg)
 	out, err := getter.GetMedia(ctx, media.GetMediaInput{ID: id})
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
## Summary
- refactor renderer to accept a `media.Getter` implementation via parameter named `getter`

## Testing
- `make clean`
- `make test` *(fails: DB setup failed: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_6869504d09f88321810da06eb4c35622