### PR TITLE
Refine HTTP renderer tests

### DIFF
--- a/internal/mock/cache.go
+++ b/internal/mock/cache.go
@@ -10,12 +10,16 @@ import (
 // MockCache implements cache behaviour for tests.
 type MockCache struct {
 	Data []byte
+	Etag string
 
 	GetMediaErr error
+	GetEtagErr  error
 	DelMediaErr error
 
 	GetMediaCalled bool
+	GetEtagCalled  bool
 	SetMediaCalled bool
+	SetEtagCalled  bool
 	DelMediaCalled bool
 	DelEtagCalled  bool
 }
@@ -29,7 +33,11 @@ func (c *MockCache) GetMediaDetails(ctx context.Context, id db.UUID) ([]byte, er
 }
 
 func (c *MockCache) GetEtagMediaDetails(ctx context.Context, id db.UUID) (string, error) {
-	return "", nil
+	c.GetEtagCalled = true
+	if c.GetEtagErr != nil {
+		return "", c.GetEtagErr
+	}
+	return c.Etag, nil
 }
 
 func (c *MockCache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte, validUntil time.Time) {
@@ -38,6 +46,8 @@ func (c *MockCache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte
 }
 
 func (c *MockCache) SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time) {
+	c.SetEtagCalled = true
+	c.Etag = etag
 }
 
 func (c *MockCache) DeleteMediaDetails(ctx context.Context, id db.UUID) error {

--- a/internal/mock/usecase.go
+++ b/internal/mock/usecase.go
@@ -1,0 +1,20 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/port"
+)
+
+// MockMediaGetter implements port.MediaGetter for tests.
+type MockMediaGetter struct {
+	Out    *port.GetMediaOutput
+	Err    error
+	Called bool
+}
+
+func (m *MockMediaGetter) GetMedia(ctx context.Context, id db.UUID) (*port.GetMediaOutput, error) {
+	m.Called = true
+	return m.Out, m.Err
+}

--- a/internal/renderer/http_renderer_test.go
+++ b/internal/renderer/http_renderer_test.go
@@ -1,0 +1,112 @@
+package renderer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"testing"
+	"time"
+
+	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
+	"github.com/fhuszti/medias-ms-go/internal/port"
+)
+
+func TestRenderGetMedia_Cases(t *testing.T) {
+	ctx := context.Background()
+	id := db.NewUUID()
+
+	t.Run("cache hit", func(t *testing.T) {
+		c := &mock.MockCache{Data: []byte(`{"ok":true}`), Etag: "\"1234\""}
+		r := NewHTTPRenderer(c)
+		getter := &mock.MockMediaGetter{}
+
+		out, etag, err := r.RenderGetMedia(ctx, getter, id)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(out) != string(c.Data) {
+			t.Errorf("raw mismatch: got %s want %s", out, c.Data)
+		}
+		if etag != c.Etag {
+			t.Errorf("etag mismatch: got %s want %s", etag, c.Etag)
+		}
+		if getter.Called {
+			t.Error("getter should not be called on cache hit")
+		}
+		if c.SetMediaCalled || c.SetEtagCalled {
+			t.Error("cache should not be set on hit")
+		}
+	})
+
+	t.Run("cache miss", func(t *testing.T) {
+		c := &mock.MockCache{}
+		now := time.Now().Add(time.Hour)
+		resp := &port.GetMediaOutput{ValidUntil: now}
+		getter := &mock.MockMediaGetter{Out: resp}
+		r := NewHTTPRenderer(c)
+
+		out, etag, err := r.RenderGetMedia(ctx, getter, id)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected, _ := json.Marshal(resp)
+		if string(out) != string(expected) {
+			t.Errorf("raw mismatch: got %s want %s", out, expected)
+		}
+		expEtag := fmt.Sprintf("\"%08x\"", crc32.ChecksumIEEE(expected))
+		if etag != expEtag {
+			t.Errorf("etag mismatch: got %s want %s", etag, expEtag)
+		}
+		if !getter.Called {
+			t.Error("getter should be called on cache miss")
+		}
+		if !c.SetMediaCalled || !c.SetEtagCalled {
+			t.Error("cache should be written on miss")
+		}
+		if string(c.Data) != string(expected) {
+			t.Errorf("cache data mismatch: got %s want %s", c.Data, expected)
+		}
+		if c.Etag != expEtag {
+			t.Errorf("cached etag mismatch: got %s want %s", c.Etag, expEtag)
+		}
+	})
+
+	t.Run("getter error", func(t *testing.T) {
+		c := &mock.MockCache{}
+		g := &mock.MockMediaGetter{Err: errors.New("fail")}
+		r := NewHTTPRenderer(c)
+
+		_, _, err := r.RenderGetMedia(ctx, g, id)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !g.Called {
+			t.Error("getter should be called when cache miss")
+		}
+		if c.SetMediaCalled || c.SetEtagCalled {
+			t.Error("cache should not be written on error")
+		}
+	})
+
+	t.Run("cache error", func(t *testing.T) {
+		c := &mock.MockCache{GetMediaErr: errors.New("boom")}
+		now := time.Now().Add(time.Hour)
+		resp := &port.GetMediaOutput{ValidUntil: now}
+		g := &mock.MockMediaGetter{Out: resp}
+		r := NewHTTPRenderer(c)
+
+		_, _, err := r.RenderGetMedia(ctx, g, id)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !g.Called {
+			t.Error("getter should be called when cache returns error")
+		}
+		if !c.SetMediaCalled || !c.SetEtagCalled {
+			t.Error("cache should be written when missing due to error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- rename mockMediaGetter struct to exported MockMediaGetter
- extend MockCache to handle ETag data and track operations
- rewrite HTTP renderer tests to use the enhanced MockCache

## Testing
- `go test ./...`
- `cd test/e2e && go test ./...` *(fails: could not start mariadb container)*
- `cd test/integration && go test ./...` *(fails: could not start mariadb container)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6869a772389083219d6d13d715a29636