### PR TITLE
Refactor service interfaces for ID parameters

### DIFF
--- a/internal/handler/api/delete_media.go
+++ b/internal/handler/api/delete_media.go
@@ -17,8 +17,7 @@ func DeleteMediaHandler(svc port.MediaDeleter) http.HandlerFunc {
 			return
 		}
 
-		in := port.DeleteMediaInput{ID: id}
-		if err := svc.DeleteMedia(r.Context(), in); err != nil {
+		if err := svc.DeleteMedia(r.Context(), id); err != nil {
 			if errors.Is(err, media.ErrObjectNotFound) {
 				WriteError(w, http.StatusNotFound, "Media not found", nil)
 				return

--- a/internal/handler/api/delete_media_test.go
+++ b/internal/handler/api/delete_media_test.go
@@ -73,13 +73,13 @@ func TestDeleteMediaHandler(t *testing.T) {
 				if rec.Body.Len() != 0 {
 					t.Errorf("expected empty body, got %q", rec.Body.String())
 				}
-				if mockSvc.In.ID != validID {
-					t.Errorf("service got ID = %s; want %s", mockSvc.In.ID, validID)
+				if mockSvc.ID != validID {
+					t.Errorf("service got ID = %s; want %s", mockSvc.ID, validID)
 				}
 			} else {
 				if !errors.Is(tc.svcErr, mediaUC.ErrObjectNotFound) && tc.ctxID != nil {
-					if mockSvc.In.ID != validID {
-						t.Errorf("service got ID = %s; want %s", mockSvc.In.ID, validID)
+					if mockSvc.ID != validID {
+						t.Errorf("service got ID = %s; want %s", mockSvc.ID, validID)
 					}
 				}
 				if !contains(rec.Body.String(), tc.wantBodySubstr) {

--- a/internal/handler/worker/optimise_media.go
+++ b/internal/handler/worker/optimise_media.go
@@ -22,8 +22,7 @@ func OptimiseMediaHandler(ctx context.Context, p task.OptimiseMediaPayload, svc 
 
 	id := uuid.MustParse(p.ID)
 
-	in := port.OptimiseMediaInput{ID: db.UUID(id)}
-	if err := svc.OptimiseMedia(ctx, in); err != nil {
+	if err := svc.OptimiseMedia(ctx, db.UUID(id)); err != nil {
 		log.Printf("❌  Failed to optimise media #%s: %v", id, err)
 		return err
 	}

--- a/internal/handler/worker/optimise_media_test.go
+++ b/internal/handler/worker/optimise_media_test.go
@@ -34,8 +34,8 @@ func TestOptimiseMediaHandler_ServiceError(t *testing.T) {
 	if !svc.Called {
 		t.Error("service not called")
 	}
-	if svc.In.ID != id {
-		t.Errorf("service got id %s; want %s", svc.In.ID, id)
+	if svc.ID != id {
+		t.Errorf("service got id %s; want %s", svc.ID, id)
 	}
 }
 
@@ -50,7 +50,7 @@ func TestOptimiseMediaHandler_Success(t *testing.T) {
 	if !svc.Called {
 		t.Error("service not called")
 	}
-	if svc.In.ID != id {
-		t.Errorf("service got id %s; want %s", svc.In.ID, id)
+	if svc.ID != id {
+		t.Errorf("service got id %s; want %s", svc.ID, id)
 	}
 }

--- a/internal/mock/usecase.go
+++ b/internal/mock/usecase.go
@@ -20,12 +20,12 @@ func (m *MediaGetter) GetMedia(ctx context.Context, id db.UUID) (*port.GetMediaO
 }
 
 type MediaDeleter struct {
-	In  port.DeleteMediaInput
+	ID  db.UUID
 	Err error
 }
 
-func (m *MediaDeleter) DeleteMedia(ctx context.Context, in port.DeleteMediaInput) error {
-	m.In = in
+func (m *MediaDeleter) DeleteMedia(ctx context.Context, id db.UUID) error {
+	m.ID = id
 	return m.Err
 }
 
@@ -51,14 +51,14 @@ func (m *UploadFinaliser) FinaliseUpload(ctx context.Context, in port.FinaliseUp
 }
 
 type MediaOptimiser struct {
-	In     port.OptimiseMediaInput
+	ID     db.UUID
 	Called bool
 	Err    error
 }
 
-func (m *MediaOptimiser) OptimiseMedia(ctx context.Context, in port.OptimiseMediaInput) error {
+func (m *MediaOptimiser) OptimiseMedia(ctx context.Context, id db.UUID) error {
 	m.Called = true
-	m.In = in
+	m.ID = id
 	return m.Err
 }
 

--- a/internal/port/usecase.go
+++ b/internal/port/usecase.go
@@ -29,10 +29,7 @@ type GetMediaOutput struct {
 
 // MediaDeleter deletes a media and its file.
 type MediaDeleter interface {
-	DeleteMedia(ctx context.Context, in DeleteMediaInput) error
-}
-type DeleteMediaInput struct {
-	ID db.UUID
+	DeleteMedia(ctx context.Context, id db.UUID) error
 }
 
 // UploadLinkGenerator returns a presigned link to upload a file.
@@ -58,10 +55,7 @@ type FinaliseUploadInput struct {
 
 // MediaOptimiser reduces the file size with different techniques.
 type MediaOptimiser interface {
-	OptimiseMedia(ctx context.Context, in OptimiseMediaInput) error
-}
-type OptimiseMediaInput struct {
-	ID db.UUID
+	OptimiseMedia(ctx context.Context, id db.UUID) error
 }
 
 // ImageResizer resizes images and saves the generated variants.

--- a/internal/usecase/media/delete_media.go
+++ b/internal/usecase/media/delete_media.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 
+	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 )
 
@@ -21,8 +22,8 @@ func NewMediaDeleter(repo port.MediaRepository, cache port.Cache, strg port.Stor
 }
 
 // DeleteMedia removes the file from storage, deletes DB record and clears the cache.
-func (s *deleteMediaSrv) DeleteMedia(ctx context.Context, in port.DeleteMediaInput) error {
-	media, err := s.repo.GetByID(ctx, in.ID)
+func (s *deleteMediaSrv) DeleteMedia(ctx context.Context, id db.UUID) error {
+	media, err := s.repo.GetByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrObjectNotFound

--- a/internal/usecase/media/delete_media_test.go
+++ b/internal/usecase/media/delete_media_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"github.com/fhuszti/medias-ms-go/internal/mock"
-	"github.com/fhuszti/medias-ms-go/internal/port"
 	"testing"
 
 	"github.com/fhuszti/medias-ms-go/internal/db"
@@ -18,7 +17,7 @@ func TestDeleteMedia_NotFound(t *testing.T) {
 	svc := NewMediaDeleter(repo, &mock.MockCache{}, &mock.MockStorage{})
 
 	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
-	err := svc.DeleteMedia(context.Background(), port.DeleteMediaInput{ID: id})
+	err := svc.DeleteMedia(context.Background(), id)
 	if !errors.Is(err, ErrObjectNotFound) {
 		t.Fatalf("expected ErrObjectNotFound, got %v", err)
 	}
@@ -29,7 +28,7 @@ func TestDeleteMedia_GetByIDError(t *testing.T) {
 	svc := NewMediaDeleter(repo, &mock.MockCache{}, &mock.MockStorage{})
 
 	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
-	if err := svc.DeleteMedia(context.Background(), port.DeleteMediaInput{ID: id}); err == nil || err.Error() != "db fail" {
+	if err := svc.DeleteMedia(context.Background(), id); err == nil || err.Error() != "db fail" {
 		t.Fatalf("expected db fail, got %v", err)
 	}
 }
@@ -40,7 +39,7 @@ func TestDeleteMedia_RemoveError(t *testing.T) {
 	strg := &mock.MockStorage{RemoveErr: errors.New("remove fail")}
 	svc := NewMediaDeleter(repo, &mock.MockCache{}, strg)
 
-	err := svc.DeleteMedia(context.Background(), port.DeleteMediaInput{ID: m.ID})
+	err := svc.DeleteMedia(context.Background(), m.ID)
 	if err == nil || err.Error() != "remove fail" {
 		t.Fatalf("expected remove fail, got %v", err)
 	}
@@ -52,7 +51,7 @@ func TestDeleteMedia_DeleteError(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaDeleter(repo, &mock.MockCache{}, strg)
 
-	err := svc.DeleteMedia(context.Background(), port.DeleteMediaInput{ID: m.ID})
+	err := svc.DeleteMedia(context.Background(), m.ID)
 	if err == nil || err.Error() != "delete fail" {
 		t.Fatalf("expected delete fail, got %v", err)
 	}
@@ -65,7 +64,7 @@ func TestDeleteMedia_Success(t *testing.T) {
 	cache := &mock.MockCache{}
 	svc := NewMediaDeleter(repo, cache, strg)
 
-	if err := svc.DeleteMedia(context.Background(), port.DeleteMediaInput{ID: m.ID}); err != nil {
+	if err := svc.DeleteMedia(context.Background(), m.ID); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strg.RemoveCalled {

--- a/internal/usecase/media/optimise_media.go
+++ b/internal/usecase/media/optimise_media.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"golang.org/x/net/context"
@@ -26,8 +27,8 @@ func NewMediaOptimiser(repo port.MediaRepository, opt port.FileOptimiser, strg p
 	return &mediaOptimiserSrv{repo, opt, strg, tasks, cache}
 }
 
-func (m *mediaOptimiserSrv) OptimiseMedia(ctx context.Context, in port.OptimiseMediaInput) error {
-	media, err := m.repo.GetByID(ctx, in.ID)
+func (m *mediaOptimiserSrv) OptimiseMedia(ctx context.Context, id db.UUID) error {
+	media, err := m.repo.GetByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrObjectNotFound

--- a/internal/usecase/media/optimise_media_test.go
+++ b/internal/usecase/media/optimise_media_test.go
@@ -32,7 +32,7 @@ func TestOptimiseMedia_GetByIDNotFound(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaOptimiser(repo, &mock.MockFileOptimiser{}, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: db.NewUUID()})
+	err := svc.OptimiseMedia(context.Background(), db.NewUUID())
 	if !errors.Is(err, ErrObjectNotFound) {
 		t.Fatalf("expected ErrObjectNotFound, got %v", err)
 	}
@@ -43,7 +43,7 @@ func TestOptimiseMedia_GetByIDError(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaOptimiser(repo, &mock.MockFileOptimiser{}, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: db.NewUUID()})
+	err := svc.OptimiseMedia(context.Background(), db.NewUUID())
 	if err == nil || err.Error() != "db fail" {
 		t.Fatalf("expected db error, got %v", err)
 	}
@@ -56,7 +56,7 @@ func TestOptimiseMedia_WrongStatus(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaOptimiser(repo, &mock.MockFileOptimiser{}, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err == nil || !strings.Contains(err.Error(), "completed") {
 		t.Fatalf("expected status error, got %v", err)
 	}
@@ -68,7 +68,7 @@ func TestOptimiseMedia_GetFileError(t *testing.T) {
 	strg := &mock.MockStorage{GetErr: errors.New("get fail")}
 	svc := NewMediaOptimiser(repo, &mock.MockFileOptimiser{}, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err == nil || err.Error() != "get fail" {
 		t.Fatalf("expected get error, got %v", err)
 	}
@@ -81,7 +81,7 @@ func TestOptimiseMedia_CompressError(t *testing.T) {
 	fo := &mock.MockFileOptimiser{CompressErr: errors.New("compress fail")}
 	svc := NewMediaOptimiser(repo, fo, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err == nil || err.Error() != "compress fail" {
 		t.Fatalf("expected compress error, got %v", err)
 	}
@@ -94,7 +94,7 @@ func TestOptimiseMedia_ExtensionError(t *testing.T) {
 	fo := &mock.MockFileOptimiser{MimeOut: "application/unknown"}
 	svc := NewMediaOptimiser(repo, fo, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err == nil || !strings.Contains(err.Error(), "unsupported mime type") {
 		t.Fatalf("expected mime type error, got %v", err)
 	}
@@ -107,7 +107,7 @@ func TestOptimiseMedia_SaveFileError(t *testing.T) {
 	fo := &mock.MockFileOptimiser{MimeOut: *m.MimeType}
 	svc := NewMediaOptimiser(repo, fo, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err == nil || !strings.Contains(err.Error(), "save fail") {
 		t.Fatalf("expected save error, got %v", err)
 	}
@@ -120,7 +120,7 @@ func TestOptimiseMedia_CopyFileError(t *testing.T) {
 	fo := &mock.MockFileOptimiser{MimeOut: *m.MimeType}
 	svc := NewMediaOptimiser(repo, fo, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err == nil || !strings.Contains(err.Error(), "copy fail") {
 		t.Fatalf("expected copy error, got %v", err)
 	}
@@ -133,7 +133,7 @@ func TestOptimiseMedia_StatError(t *testing.T) {
 	fo := &mock.MockFileOptimiser{MimeOut: *m.MimeType}
 	svc := NewMediaOptimiser(repo, fo, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err == nil || !strings.Contains(err.Error(), "stat fail") {
 		t.Fatalf("expected stat error, got %v", err)
 	}
@@ -147,7 +147,7 @@ func TestOptimiseMedia_UpdateError(t *testing.T) {
 	fo := &mock.MockFileOptimiser{MimeOut: *m.MimeType}
 	svc := NewMediaOptimiser(repo, fo, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err == nil || !strings.Contains(err.Error(), "update fail") {
 		t.Fatalf("expected update error, got %v", err)
 	}
@@ -162,7 +162,7 @@ func TestOptimiseMedia_SuccessSameMime(t *testing.T) {
 	dispatcher := &mock.MockDispatcher{}
 	svc := NewMediaOptimiser(repo, fo, strg, dispatcher, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestOptimiseMedia_SuccessMimeChange(t *testing.T) {
 	dispatcher := &mock.MockDispatcher{}
 	svc := NewMediaOptimiser(repo, fo, strg, dispatcher, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), port.OptimiseMediaInput{ID: m.ID})
+	err := svc.OptimiseMedia(context.Background(), m.ID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/delete_media_test.go
+++ b/test/integration/delete_media_test.go
@@ -99,7 +99,7 @@ func TestDeleteMediaIntegration_Success(t *testing.T) {
 		t.Fatalf("insert media: %v", err)
 	}
 
-	if err := svc.DeleteMedia(ctx, port.DeleteMediaInput{ID: id}); err != nil {
+	if err := svc.DeleteMedia(ctx, id); err != nil {
 		t.Fatalf("DeleteMedia returned error: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- simplify `MediaDeleter` and `MediaOptimiser` interfaces to take IDs directly
- update handlers, use cases, mocks and tests accordingly

## Testing
- `go test ./...`
- `cd test/e2e && go test ./...` *(fails: dial unix /var/run/docker.sock: connect: no such file or directory)*
- `cd test/integration && go test ./...` *(fails: dial unix /var/run/docker.sock: connect: no such file or directory)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_686c419ef0708321a91c068b2fbd2679