### PR TITLE
Add compile-time checks for usecase services

### DIFF
--- a/internal/usecase/media/delete_media.go
+++ b/internal/usecase/media/delete_media.go
@@ -16,6 +16,9 @@ type deleteMediaSrv struct {
 	strg  port.Storage
 }
 
+// compile-time check: *deleteMediaSrv must satisfy port.MediaDeleter
+var _ port.MediaDeleter = (*deleteMediaSrv)(nil)
+
 // NewMediaDeleter constructs a MediaDeleter implementation.
 func NewMediaDeleter(repo port.MediaRepository, cache port.Cache, strg port.Storage) port.MediaDeleter {
 	return &deleteMediaSrv{repo: repo, cache: cache, strg: strg}

--- a/internal/usecase/media/finalise_upload.go
+++ b/internal/usecase/media/finalise_upload.go
@@ -26,6 +26,9 @@ type uploadFinaliserSrv struct {
 	tasks port.TaskDispatcher
 }
 
+// compile-time check: *uploadFinaliserSrv must satisfy port.UploadFinaliser
+var _ port.UploadFinaliser = (*uploadFinaliserSrv)(nil)
+
 func NewUploadFinaliser(repo port.MediaRepository, strg port.Storage, tasks port.TaskDispatcher) port.UploadFinaliser {
 	return &uploadFinaliserSrv{repo, strg, tasks}
 }

--- a/internal/usecase/media/generate_upload_link.go
+++ b/internal/usecase/media/generate_upload_link.go
@@ -14,6 +14,9 @@ type uploadLinkGeneratorSrv struct {
 	genUUID port.UUIDGen
 }
 
+// compile-time check: *uploadLinkGeneratorSrv must satisfy port.UploadLinkGenerator
+var _ port.UploadLinkGenerator = (*uploadLinkGeneratorSrv)(nil)
+
 func NewUploadLinkGenerator(repo port.MediaRepository, strg port.Storage, genUUID port.UUIDGen) port.UploadLinkGenerator {
 	return &uploadLinkGeneratorSrv{repo, strg, genUUID}
 }

--- a/internal/usecase/media/get_media.go
+++ b/internal/usecase/media/get_media.go
@@ -18,6 +18,9 @@ type mediaGetterSrv struct {
 	strg port.Storage
 }
 
+// compile-time check: *mediaGetterSrv must satisfy port.MediaGetter
+var _ port.MediaGetter = (*mediaGetterSrv)(nil)
+
 func NewMediaGetter(repo port.MediaRepository, strg port.Storage) port.MediaGetter {
 	return &mediaGetterSrv{repo: repo, strg: strg}
 }

--- a/internal/usecase/media/optimise_backlog.go
+++ b/internal/usecase/media/optimise_backlog.go
@@ -13,6 +13,9 @@ type backlogOptimiserSrv struct {
 	tasks port.TaskDispatcher
 }
 
+// compile-time check: *backlogOptimiserSrv must satisfy port.BacklogOptimiser
+var _ port.BacklogOptimiser = (*backlogOptimiserSrv)(nil)
+
 // NewBacklogOptimiser constructs a BacklogOptimiser implementation.
 func NewBacklogOptimiser(repo port.MediaRepository, tasks port.TaskDispatcher) port.BacklogOptimiser {
 	return &backlogOptimiserSrv{repo, tasks}

--- a/internal/usecase/media/optimise_media.go
+++ b/internal/usecase/media/optimise_media.go
@@ -23,6 +23,9 @@ type mediaOptimiserSrv struct {
 	cache port.Cache
 }
 
+// compile-time check: *mediaOptimiserSrv must satisfy port.MediaOptimiser
+var _ port.MediaOptimiser = (*mediaOptimiserSrv)(nil)
+
 func NewMediaOptimiser(repo port.MediaRepository, opt port.FileOptimiser, strg port.Storage, tasks port.TaskDispatcher, cache port.Cache) port.MediaOptimiser {
 	return &mediaOptimiserSrv{repo, opt, strg, tasks, cache}
 }

--- a/internal/usecase/media/resize_image.go
+++ b/internal/usecase/media/resize_image.go
@@ -21,6 +21,9 @@ type imageResizerSrv struct {
 	cache port.Cache
 }
 
+// compile-time check: *imageResizerSrv must satisfy port.ImageResizer
+var _ port.ImageResizer = (*imageResizerSrv)(nil)
+
 // NewImageResizer constructs an ImageResizer implementation.
 func NewImageResizer(repo port.MediaRepository, opt port.FileOptimiser, strg port.Storage, cache port.Cache) port.ImageResizer {
 	return &imageResizerSrv{repo, opt, strg, cache}


### PR DESCRIPTION
## Summary
- enforce compile-time interface checks in use case services

## Testing
- `make clean`
- `make test` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_686d85eb0f2c8321aa2736edf3a1bb59