### PR TITLE
Move UUID type to dedicated package

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/storage"
 	"github.com/fhuszti/medias-ms-go/internal/task"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -51,7 +52,7 @@ func main() {
 		log.Println("⚠️  Redis not configured — caching is disabled")
 	}
 
-	uploadLinkGeneratorSvc := mediaSvc.NewUploadLinkGenerator(mediaRepo, strg, db.NewUUID)
+	uploadLinkGeneratorSvc := mediaSvc.NewUploadLinkGenerator(mediaRepo, strg, msuuid.NewUUID)
 	r.Post("/medias/generate_upload_link", api.GenerateUploadLinkHandler(uploadLinkGeneratorSvc))
 
 	uploadFinaliserSvc := mediaSvc.NewUploadFinaliser(mediaRepo, strg, dispatcher)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -30,7 +30,7 @@ func NewCache(addr, password string) *Cache {
 	return &Cache{client: rdb}
 }
 
-func (c *Cache) GetMediaDetails(ctx context.Context, id db.UUID) ([]byte, error) {
+func (c *Cache) GetMediaDetails(ctx context.Context, id uuid.UUID) ([]byte, error) {
 	log.Printf("getting entry in cache for media #%s...", id)
 
 	val, err := c.client.Get(ctx, getCacheKey(id.String(), false)).Result()
@@ -47,7 +47,7 @@ func (c *Cache) GetMediaDetails(ctx context.Context, id db.UUID) ([]byte, error)
 	return data, nil
 }
 
-func (c *Cache) GetEtagMediaDetails(ctx context.Context, id db.UUID) (string, error) {
+func (c *Cache) GetEtagMediaDetails(ctx context.Context, id uuid.UUID) (string, error) {
 	log.Printf("getting etag in cache for media #%s...", id)
 
 	val, err := c.client.Get(ctx, getCacheKey(id.String(), true)).Result()
@@ -61,7 +61,7 @@ func (c *Cache) GetEtagMediaDetails(ctx context.Context, id db.UUID) (string, er
 	return val, nil
 }
 
-func (c *Cache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte, validUntil time.Time) {
+func (c *Cache) SetMediaDetails(ctx context.Context, id uuid.UUID, data []byte, validUntil time.Time) {
 	log.Printf("creating entry in cache for media #%s, valid until %s...", id, validUntil.Format(time.RFC1123))
 	exp := time.Until(validUntil)
 
@@ -70,7 +70,7 @@ func (c *Cache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte, va
 	}
 }
 
-func (c *Cache) SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time) {
+func (c *Cache) SetEtagMediaDetails(ctx context.Context, id uuid.UUID, etag string, validUntil time.Time) {
 	log.Printf("creating etag in cache for media #%s, valid until %s...", id, validUntil.Format(time.RFC1123))
 	exp := time.Until(validUntil)
 
@@ -79,7 +79,7 @@ func (c *Cache) SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string
 	}
 }
 
-func (c *Cache) DeleteMediaDetails(ctx context.Context, id db.UUID) error {
+func (c *Cache) DeleteMediaDetails(ctx context.Context, id uuid.UUID) error {
 	log.Printf("deleting entry in cache for media #%s...", id)
 
 	if err := c.client.Del(ctx, getCacheKey(id.String(), false)).Err(); err != nil {
@@ -88,7 +88,7 @@ func (c *Cache) DeleteMediaDetails(ctx context.Context, id db.UUID) error {
 	return nil
 }
 
-func (c *Cache) DeleteEtagMediaDetails(ctx context.Context, id db.UUID) error {
+func (c *Cache) DeleteEtagMediaDetails(ctx context.Context, id uuid.UUID) error {
 	log.Printf("deleting etag in cache for media #%s...", id)
 
 	if err := c.client.Del(ctx, getCacheKey(id.String(), true)).Err(); err != nil {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -36,7 +36,7 @@ func TestGetSetDeleteMediaDetails(t *testing.T) {
 	ctx := context.Background()
 
 	// prepare a sample GetMediaOutput
-	id := db.NewUUID()
+	id := msuuid.NewUUID()
 	out := &port.GetMediaOutput{
 		ValidUntil: time.Now().Add(2 * time.Minute),
 		Optimised:  false,
@@ -104,7 +104,7 @@ func TestGetSetDeleteMediaDetails(t *testing.T) {
 func TestGetMediaDetails_BadJSON(t *testing.T) {
 	c, mr := makeTestCache(t)
 	ctx := context.Background()
-	id := db.NewUUID()
+	id := msuuid.NewUUID()
 
 	// inject invalid JSON into Redis
 	if err := mr.Set(getCacheKey(id.String(), false), "{ not valid json }"); err != nil {
@@ -123,7 +123,7 @@ func TestGetMediaDetails_BadJSON(t *testing.T) {
 func TestGetMediaDetails_RedisError(t *testing.T) {
 	c, mr := makeTestCache(t)
 	ctx := context.Background()
-	id := db.NewUUID()
+	id := msuuid.NewUUID()
 
 	// Simulate Redis unreachable
 	mr.Close()
@@ -140,7 +140,7 @@ func TestGetMediaDetails_RedisError(t *testing.T) {
 func TestDeleteMediaDetails_RedisError(t *testing.T) {
 	c, mr := makeTestCache(t)
 	ctx := context.Background()
-	id := db.NewUUID()
+	id := msuuid.NewUUID()
 
 	// Simulate Redis unreachable before Delete
 	mr.Close()
@@ -155,7 +155,7 @@ func TestDeleteEtagMediaDetails(t *testing.T) {
 	c, _ := makeTestCache(t)
 	ctx := context.Background()
 
-	id := db.NewUUID()
+	id := msuuid.NewUUID()
 	out := &port.GetMediaOutput{ValidUntil: time.Now().Add(2 * time.Minute)}
 	raw, _ := json.Marshal(out)
 	etag := fmt.Sprintf("%08x", crc32.ChecksumIEEE(raw))
@@ -173,7 +173,7 @@ func TestDeleteEtagMediaDetails(t *testing.T) {
 func TestDeleteEtagMediaDetails_RedisError(t *testing.T) {
 	c, mr := makeTestCache(t)
 	ctx := context.Background()
-	id := db.NewUUID()
+	id := msuuid.NewUUID()
 
 	mr.Close()
 	err := c.DeleteEtagMediaDetails(ctx, id)
@@ -183,7 +183,7 @@ func TestDeleteEtagMediaDetails_RedisError(t *testing.T) {
 }
 
 func TestGetCacheKey_Etag(t *testing.T) {
-	id := db.NewUUID().String()
+	id := msuuid.NewUUID().String()
 	if got := getCacheKey(id, true); got != "etag:media:"+id {
 		t.Errorf("getCacheKey(true) = %q; want %q", got, "etag:media:"+id)
 	}
@@ -196,7 +196,7 @@ func TestGetEtagMediaDetails(t *testing.T) {
 	c, mr := makeTestCache(t)
 	ctx := context.Background()
 
-	id := db.NewUUID()
+	id := msuuid.NewUUID()
 	if got, err := c.GetEtagMediaDetails(ctx, id); err != nil {
 		t.Fatalf("initial miss err: %v", err)
 	} else if got != "" {

--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type NoopCache struct{}
@@ -17,22 +17,22 @@ func NewNoop() *NoopCache {
 	return &NoopCache{}
 }
 
-func (n *NoopCache) GetMediaDetails(ctx context.Context, id db.UUID) ([]byte, error) {
+func (n *NoopCache) GetMediaDetails(ctx context.Context, id uuid.UUID) ([]byte, error) {
 	return nil, nil // always cache miss
 }
 
-func (n *NoopCache) GetEtagMediaDetails(ctx context.Context, id db.UUID) (string, error) {
+func (n *NoopCache) GetEtagMediaDetails(ctx context.Context, id uuid.UUID) (string, error) {
 	return "", nil
 }
 
-func (n *NoopCache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte, validUntil time.Time) {
+func (n *NoopCache) SetMediaDetails(ctx context.Context, id uuid.UUID, data []byte, validUntil time.Time) {
 }
 
-func (n *NoopCache) SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time) {
+func (n *NoopCache) SetEtagMediaDetails(ctx context.Context, id uuid.UUID, etag string, validUntil time.Time) {
 }
 
-func (n *NoopCache) DeleteMediaDetails(ctx context.Context, id db.UUID) error { return nil }
+func (n *NoopCache) DeleteMediaDetails(ctx context.Context, id uuid.UUID) error { return nil }
 
-func (n *NoopCache) DeleteEtagMediaDetails(ctx context.Context, id db.UUID) error {
+func (n *NoopCache) DeleteEtagMediaDetails(ctx context.Context, id uuid.UUID) error {
 	return nil
 }

--- a/internal/handler/api/context_keys.go
+++ b/internal/handler/api/context_keys.go
@@ -2,14 +2,15 @@ package api
 
 import (
 	"context"
-	"github.com/fhuszti/medias-ms-go/internal/db"
+
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type ctxKey string
 
 const IDKey ctxKey = "id"
 
-func IDFromContext(ctx context.Context) (db.UUID, bool) {
-	id, ok := ctx.Value(IDKey).(db.UUID)
+func IDFromContext(ctx context.Context) (uuid.UUID, bool) {
+	id, ok := ctx.Value(IDKey).(uuid.UUID)
 	return id, ok
 }

--- a/internal/handler/api/delete_media_test.go
+++ b/internal/handler/api/delete_media_test.go
@@ -3,22 +3,22 @@ package api
 import (
 	"context"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
 	mediaUC "github.com/fhuszti/medias-ms-go/internal/usecase/media"
-	"github.com/google/uuid"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+	guuid "github.com/google/uuid"
 )
 
 func TestDeleteMediaHandler(t *testing.T) {
-	validID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	validID := msuuid.UUID(guuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	tests := []struct {
 		name           string
-		ctxID          *db.UUID
+		ctxID          *msuuid.UUID
 		svcErr         error
 		wantStatus     int
 		wantBodySubstr string

--- a/internal/handler/api/finalise_upload_test.go
+++ b/internal/handler/api/finalise_upload_test.go
@@ -2,21 +2,21 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"context"
-	"github.com/fhuszti/medias-ms-go/internal/db"
-	"github.com/google/uuid"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+	guuid "github.com/google/uuid"
 )
 
 func TestFinaliseUploadHandler(t *testing.T) {
-	validID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	validID := msuuid.UUID(guuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	tests := []struct {
 		name            string
 		ctxID           bool

--- a/internal/handler/api/get_media_test.go
+++ b/internal/handler/api/get_media_test.go
@@ -6,9 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/fhuszti/medias-ms-go/internal/db"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
-	"github.com/google/uuid"
 	"hash/crc32"
 	"net/http"
 	"net/http/httptest"
@@ -16,8 +13,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+	guuid "github.com/google/uuid"
 )
 
 func computeETag(t testing.TB, v any) string {
@@ -30,14 +30,14 @@ func computeETag(t testing.TB, v any) string {
 }
 
 func TestGetMediaHandler(t *testing.T) {
-	validID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	validID := msuuid.UUID(guuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	nonEmptyVariants := model.VariantsOutput{
 		model.VariantOutput{Width: 100, Height: 50, SizeBytes: 1234, URL: "https://cdn.example.com/foo_100"},
 	}
 
 	tests := []struct {
 		name             string
-		ctxID            *db.UUID
+		ctxID            *msuuid.UUID
 		svcOut           port.GetMediaOutput
 		svcErr           error
 		wantStatus       int
@@ -182,7 +182,7 @@ func TestGetMediaHandler(t *testing.T) {
 }
 
 func TestGetMediaHandler_IfNoneMatch(t *testing.T) {
-	validID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	validID := msuuid.UUID(guuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	mockSvc := &mock.MediaGetter{
 		Out: &port.GetMediaOutput{
 			ValidUntil: time.Now(),

--- a/internal/handler/api/get_upload_link_test.go
+++ b/internal/handler/api/get_upload_link_test.go
@@ -5,15 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
-	"github.com/fhuszti/medias-ms-go/internal/port"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
-	"github.com/google/uuid"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
+	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+	guuid "github.com/google/uuid"
 )
 
 func TestGenerateUploadLinkHandler(t *testing.T) {
@@ -32,7 +32,7 @@ func TestGenerateUploadLinkHandler(t *testing.T) {
 		{
 			name:            "happy path",
 			body:            `{"name":"my-file.png"}`,
-			svcOut:          port.GenerateUploadLinkOutput{ID: db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), URL: "https://cdn.example.com/presigned"},
+			svcOut:          port.GenerateUploadLinkOutput{ID: msuuid.UUID(guuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), URL: "https://cdn.example.com/presigned"},
 			svcErr:          nil,
 			wantStatus:      http.StatusCreated,
 			wantContentType: "application/json",

--- a/internal/handler/api/middleware.go
+++ b/internal/handler/api/middleware.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/google/uuid"
+	guuid "github.com/google/uuid"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -21,14 +21,14 @@ func WithID() func(http.Handler) http.Handler {
 				WriteError(w, http.StatusBadRequest, "ID is required", nil)
 				return
 			}
-			parsedID, err := uuid.Parse(id)
+			parsedID, err := guuid.Parse(id)
 			if err != nil {
 				WriteError(w, http.StatusBadRequest, fmt.Sprintf("ID %q is not a valid UUID", id), nil)
 				return
 			}
 
 			// stash it in context and call the real handler
-			ctx := context.WithValue(r.Context(), IDKey, db.UUID(parsedID))
+			ctx := context.WithValue(r.Context(), IDKey, msuuid.UUID(parsedID))
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/internal/handler/worker/optimise_media.go
+++ b/internal/handler/worker/optimise_media.go
@@ -2,11 +2,11 @@ package worker
 
 import (
 	"context"
-	"github.com/fhuszti/medias-ms-go/internal/port"
 	"log"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/task"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/internal/validation"
 	"github.com/google/uuid"
 )
@@ -22,7 +22,7 @@ func OptimiseMediaHandler(ctx context.Context, p task.OptimiseMediaPayload, svc 
 
 	id := uuid.MustParse(p.ID)
 
-	if err := svc.OptimiseMedia(ctx, db.UUID(id)); err != nil {
+	if err := svc.OptimiseMedia(ctx, msuuid.UUID(id)); err != nil {
 		log.Printf("❌  Failed to optimise media #%s: %v", id, err)
 		return err
 	}

--- a/internal/handler/worker/optimise_media_test.go
+++ b/internal/handler/worker/optimise_media_test.go
@@ -3,11 +3,11 @@ package worker
 import (
 	"context"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/task"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/google/uuid"
 )
 
@@ -23,7 +23,7 @@ func TestOptimiseMediaHandler_InvalidID(t *testing.T) {
 }
 
 func TestOptimiseMediaHandler_ServiceError(t *testing.T) {
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	svcErr := errors.New("svc fail")
 	svc := &mock.MediaOptimiser{Err: svcErr}
 
@@ -40,7 +40,7 @@ func TestOptimiseMediaHandler_ServiceError(t *testing.T) {
 }
 
 func TestOptimiseMediaHandler_Success(t *testing.T) {
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	svc := &mock.MediaOptimiser{}
 
 	err := OptimiseMediaHandler(context.Background(), task.OptimiseMediaPayload{ID: id.String()}, svc)

--- a/internal/handler/worker/resize_image.go
+++ b/internal/handler/worker/resize_image.go
@@ -2,11 +2,11 @@ package worker
 
 import (
 	"context"
-	"github.com/fhuszti/medias-ms-go/internal/port"
 	"log"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/task"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/internal/validation"
 	"github.com/google/uuid"
 )
@@ -20,7 +20,7 @@ func ResizeImageHandler(ctx context.Context, p task.ResizeImagePayload, sizes []
 	}
 
 	id := uuid.MustParse(p.ID)
-	in := port.ResizeImageInput{ID: db.UUID(id), Sizes: sizes}
+	in := port.ResizeImageInput{ID: msuuid.UUID(id), Sizes: sizes}
 	if err := svc.ResizeImage(ctx, in); err != nil {
 		log.Printf("❌  Failed to resize image #%s: %v", id, err)
 		return err

--- a/internal/handler/worker/resize_image_test.go
+++ b/internal/handler/worker/resize_image_test.go
@@ -3,11 +3,11 @@ package worker
 import (
 	"context"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/task"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/google/uuid"
 )
 
@@ -23,7 +23,7 @@ func TestResizeImageHandler_InvalidID(t *testing.T) {
 }
 
 func TestResizeImageHandler_ServiceError(t *testing.T) {
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	svcErr := errors.New("svc fail")
 	svc := &mock.ImageResizer{Err: svcErr}
 
@@ -44,7 +44,7 @@ func TestResizeImageHandler_ServiceError(t *testing.T) {
 }
 
 func TestResizeImageHandler_Success(t *testing.T) {
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	svc := &mock.ImageResizer{}
 	sizes := []int{100, 200}
 

--- a/internal/mock/cache.go
+++ b/internal/mock/cache.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 // MockCache implements cache behaviour for tests.
@@ -24,7 +24,7 @@ type MockCache struct {
 	DelEtagCalled  bool
 }
 
-func (c *MockCache) GetMediaDetails(ctx context.Context, id db.UUID) ([]byte, error) {
+func (c *MockCache) GetMediaDetails(ctx context.Context, id uuid.UUID) ([]byte, error) {
 	c.GetMediaCalled = true
 	if c.GetMediaErr != nil {
 		return nil, c.GetMediaErr
@@ -32,7 +32,7 @@ func (c *MockCache) GetMediaDetails(ctx context.Context, id db.UUID) ([]byte, er
 	return c.Data, nil
 }
 
-func (c *MockCache) GetEtagMediaDetails(ctx context.Context, id db.UUID) (string, error) {
+func (c *MockCache) GetEtagMediaDetails(ctx context.Context, id uuid.UUID) (string, error) {
 	c.GetEtagCalled = true
 	if c.GetEtagErr != nil {
 		return "", c.GetEtagErr
@@ -40,22 +40,22 @@ func (c *MockCache) GetEtagMediaDetails(ctx context.Context, id db.UUID) (string
 	return c.Etag, nil
 }
 
-func (c *MockCache) SetMediaDetails(ctx context.Context, id db.UUID, data []byte, validUntil time.Time) {
+func (c *MockCache) SetMediaDetails(ctx context.Context, id uuid.UUID, data []byte, validUntil time.Time) {
 	c.SetMediaCalled = true
 	c.Data = data
 }
 
-func (c *MockCache) SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time) {
+func (c *MockCache) SetEtagMediaDetails(ctx context.Context, id uuid.UUID, etag string, validUntil time.Time) {
 	c.SetEtagCalled = true
 	c.Etag = etag
 }
 
-func (c *MockCache) DeleteMediaDetails(ctx context.Context, id db.UUID) error {
+func (c *MockCache) DeleteMediaDetails(ctx context.Context, id uuid.UUID) error {
 	c.DelMediaCalled = true
 	return c.DelMediaErr
 }
 
-func (c *MockCache) DeleteEtagMediaDetails(ctx context.Context, id db.UUID) error {
+func (c *MockCache) DeleteEtagMediaDetails(ctx context.Context, id uuid.UUID) error {
 	c.DelEtagCalled = true
 	return nil
 }

--- a/internal/mock/media_repository.go
+++ b/internal/mock/media_repository.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 // MockMediaRepo implements repository operations for tests.
@@ -17,11 +17,11 @@ type MockMediaRepo struct {
 	UpdateErr  error
 	DeleteErr  error
 	ListErr    error
-	ListOut    []db.UUID
+	ListOut    []uuid.UUID
 	ListBefore time.Time
 
 	ListVariantsErr    error
-	ListVariantsOut    []db.UUID
+	ListVariantsOut    []uuid.UUID
 	ListVariantsBefore time.Time
 
 	ListVariantsCalled bool
@@ -30,11 +30,11 @@ type MockMediaRepo struct {
 	Created      *model.Media
 	Updated      *model.Media
 	DeleteCalled bool
-	DeletedID    db.UUID
+	DeletedID    uuid.UUID
 	ListCalled   bool
 }
 
-func (m *MockMediaRepo) GetByID(ctx context.Context, id db.UUID) (*model.Media, error) {
+func (m *MockMediaRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Media, error) {
 	m.GetCalled = true
 	if m.GetErr != nil {
 		return nil, m.GetErr
@@ -52,13 +52,13 @@ func (m *MockMediaRepo) Create(ctx context.Context, media *model.Media) error {
 	return m.CreateErr
 }
 
-func (m *MockMediaRepo) Delete(ctx context.Context, id db.UUID) error {
+func (m *MockMediaRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	m.DeleteCalled = true
 	m.DeletedID = id
 	return m.DeleteErr
 }
 
-func (m *MockMediaRepo) ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]db.UUID, error) {
+func (m *MockMediaRepo) ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]uuid.UUID, error) {
 	m.ListCalled = true
 	m.ListBefore = before
 	if m.ListErr != nil {
@@ -67,7 +67,7 @@ func (m *MockMediaRepo) ListUnoptimisedCompletedBefore(ctx context.Context, befo
 	return m.ListOut, nil
 }
 
-func (m *MockMediaRepo) ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]db.UUID, error) {
+func (m *MockMediaRepo) ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]uuid.UUID, error) {
 	m.ListVariantsCalled = true
 	m.ListVariantsBefore = before
 	if m.ListVariantsErr != nil {

--- a/internal/mock/task_dispatcher.go
+++ b/internal/mock/task_dispatcher.go
@@ -3,27 +3,27 @@ package mock
 import (
 	"context"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 // MockDispatcher implements task dispatching for tests.
 type MockDispatcher struct {
 	OptimiseCalled bool
-	OptimiseIDs    []db.UUID
+	OptimiseIDs    []uuid.UUID
 	OptimiseErr    error
 
 	ResizeCalled bool
-	ResizeIDs    []db.UUID
+	ResizeIDs    []uuid.UUID
 	ResizeErr    error
 }
 
-func (m *MockDispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error {
+func (m *MockDispatcher) EnqueueOptimiseMedia(ctx context.Context, id uuid.UUID) error {
 	m.OptimiseCalled = true
 	m.OptimiseIDs = append(m.OptimiseIDs, id)
 	return m.OptimiseErr
 }
 
-func (m *MockDispatcher) EnqueueResizeImage(ctx context.Context, id db.UUID) error {
+func (m *MockDispatcher) EnqueueResizeImage(ctx context.Context, id uuid.UUID) error {
 	m.ResizeCalled = true
 	m.ResizeIDs = append(m.ResizeIDs, id)
 	return m.ResizeErr

--- a/internal/mock/usecase.go
+++ b/internal/mock/usecase.go
@@ -2,29 +2,30 @@ package mock
 
 import (
 	"context"
-	"github.com/fhuszti/medias-ms-go/internal/db"
+
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type MediaGetter struct {
 	Out    *port.GetMediaOutput
-	Id     db.UUID
+	Id     uuid.UUID
 	Err    error
 	Called bool
 }
 
-func (m *MediaGetter) GetMedia(ctx context.Context, id db.UUID) (*port.GetMediaOutput, error) {
+func (m *MediaGetter) GetMedia(ctx context.Context, id uuid.UUID) (*port.GetMediaOutput, error) {
 	m.Id = id
 	m.Called = true
 	return m.Out, m.Err
 }
 
 type MediaDeleter struct {
-	ID  db.UUID
+	ID  uuid.UUID
 	Err error
 }
 
-func (m *MediaDeleter) DeleteMedia(ctx context.Context, id db.UUID) error {
+func (m *MediaDeleter) DeleteMedia(ctx context.Context, id uuid.UUID) error {
 	m.ID = id
 	return m.Err
 }
@@ -51,12 +52,12 @@ func (m *UploadFinaliser) FinaliseUpload(ctx context.Context, in port.FinaliseUp
 }
 
 type MediaOptimiser struct {
-	ID     db.UUID
+	ID     uuid.UUID
 	Called bool
 	Err    error
 }
 
-func (m *MediaOptimiser) OptimiseMedia(ctx context.Context, id db.UUID) error {
+func (m *MediaOptimiser) OptimiseMedia(ctx context.Context, id uuid.UUID) error {
 	m.Called = true
 	m.ID = id
 	return m.Err

--- a/internal/model/media.go
+++ b/internal/model/media.go
@@ -1,8 +1,9 @@
 package model
 
 import (
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"time"
+
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type MediaStatus string
@@ -14,7 +15,7 @@ const (
 )
 
 type Media struct {
-	ID               db.UUID     `json:"id"`
+	ID               uuid.UUID   `json:"id"`
 	ObjectKey        string      `json:"object_key"`
 	Bucket           string      `json:"bucket"`
 	OriginalFilename string      `json:"original_filename"`

--- a/internal/port/cache.go
+++ b/internal/port/cache.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 // Cache provides caching capabilities for media retrieval.
 type Cache interface {
-	GetMediaDetails(ctx context.Context, id db.UUID) ([]byte, error)
-	GetEtagMediaDetails(ctx context.Context, id db.UUID) (string, error)
-	SetMediaDetails(ctx context.Context, id db.UUID, data []byte, validUntil time.Time)
-	SetEtagMediaDetails(ctx context.Context, id db.UUID, etag string, validUntil time.Time)
-	DeleteMediaDetails(ctx context.Context, id db.UUID) error
-	DeleteEtagMediaDetails(ctx context.Context, id db.UUID) error
+	GetMediaDetails(ctx context.Context, id uuid.UUID) ([]byte, error)
+	GetEtagMediaDetails(ctx context.Context, id uuid.UUID) (string, error)
+	SetMediaDetails(ctx context.Context, id uuid.UUID, data []byte, validUntil time.Time)
+	SetEtagMediaDetails(ctx context.Context, id uuid.UUID, etag string, validUntil time.Time)
+	DeleteMediaDetails(ctx context.Context, id uuid.UUID) error
+	DeleteEtagMediaDetails(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/port/media_repository.go
+++ b/internal/port/media_repository.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 // MediaRepository defines persistence operations for medias.
 type MediaRepository interface {
 	Create(ctx context.Context, media *model.Media) error
 	Update(ctx context.Context, media *model.Media) error
-	GetByID(ctx context.Context, ID db.UUID) (*model.Media, error)
-	Delete(ctx context.Context, ID db.UUID) error
-	ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]db.UUID, error)
-	ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]db.UUID, error)
+	GetByID(ctx context.Context, ID uuid.UUID) (*model.Media, error)
+	Delete(ctx context.Context, ID uuid.UUID) error
+	ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]uuid.UUID, error)
+	ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]uuid.UUID, error)
 }

--- a/internal/port/renderer.go
+++ b/internal/port/renderer.go
@@ -3,7 +3,7 @@ package port
 import (
 	"context"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 // HTTPRenderer mediates between HTTP handlers and the media getter use case.
@@ -12,5 +12,5 @@ import (
 type HTTPRenderer interface {
 	// RenderGetMedia returns the cached JSON result and its ETag if available or
 	// executes the underlying use case and caches the output otherwise.
-	RenderGetMedia(ctx context.Context, getter MediaGetter, id db.UUID) ([]byte, string, error)
+	RenderGetMedia(ctx context.Context, getter MediaGetter, id uuid.UUID) ([]byte, string, error)
 }

--- a/internal/port/task_dispatcher.go
+++ b/internal/port/task_dispatcher.go
@@ -3,11 +3,11 @@ package port
 import (
 	"context"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 // TaskDispatcher enqueues asynchronous tasks related to media processing.
 type TaskDispatcher interface {
-	EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error
-	EnqueueResizeImage(ctx context.Context, id db.UUID) error
+	EnqueueOptimiseMedia(ctx context.Context, id uuid.UUID) error
+	EnqueueResizeImage(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/port/usecase.go
+++ b/internal/port/usecase.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
-type UUIDGen func() db.UUID
+type UUIDGen func() uuid.UUID
 
 // MediaGetter retrieves media information from the repository and storage.
 type MediaGetter interface {
-	GetMedia(ctx context.Context, id db.UUID) (*GetMediaOutput, error)
+	GetMedia(ctx context.Context, id uuid.UUID) (*GetMediaOutput, error)
 }
 type MetadataOutput struct {
 	model.Metadata
@@ -29,7 +29,7 @@ type GetMediaOutput struct {
 
 // MediaDeleter deletes a media and its file.
 type MediaDeleter interface {
-	DeleteMedia(ctx context.Context, id db.UUID) error
+	DeleteMedia(ctx context.Context, id uuid.UUID) error
 }
 
 // UploadLinkGenerator returns a presigned link to upload a file.
@@ -40,8 +40,8 @@ type GenerateUploadLinkInput struct {
 	Name string
 }
 type GenerateUploadLinkOutput struct {
-	ID  db.UUID `json:"id"`
-	URL string  `json:"url"`
+	ID  uuid.UUID `json:"id"`
+	URL string    `json:"url"`
 }
 
 // UploadFinaliser validates the given media in the staging bucket and moves it to the destination bucket.
@@ -49,13 +49,13 @@ type UploadFinaliser interface {
 	FinaliseUpload(ctx context.Context, in FinaliseUploadInput) error
 }
 type FinaliseUploadInput struct {
-	ID         db.UUID
+	ID         uuid.UUID
 	DestBucket string
 }
 
 // MediaOptimiser reduces the file size with different techniques.
 type MediaOptimiser interface {
-	OptimiseMedia(ctx context.Context, id db.UUID) error
+	OptimiseMedia(ctx context.Context, id uuid.UUID) error
 }
 
 // ImageResizer resizes images and saves the generated variants.
@@ -63,7 +63,7 @@ type ImageResizer interface {
 	ResizeImage(ctx context.Context, in ResizeImageInput) error
 }
 type ResizeImageInput struct {
-	ID    db.UUID
+	ID    uuid.UUID
 	Sizes []int
 }
 

--- a/internal/renderer/http_renderer.go
+++ b/internal/renderer/http_renderer.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"hash/crc32"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type httpRenderer struct {
@@ -24,7 +24,7 @@ func NewHTTPRenderer(cache port.Cache) port.HTTPRenderer {
 
 // RenderGetMedia fetches media details either from cache or from the wrapped use
 // case. It returns the JSON encoded output and a quoted ETag string.
-func (r *httpRenderer) RenderGetMedia(ctx context.Context, getter port.MediaGetter, id db.UUID) ([]byte, string, error) {
+func (r *httpRenderer) RenderGetMedia(ctx context.Context, getter port.MediaGetter, id uuid.UUID) ([]byte, string, error) {
 	raw, err := r.cache.GetMediaDetails(ctx, id)
 	etag, errEtag := r.cache.GetEtagMediaDetails(ctx, id)
 	if err == nil && errEtag == nil && raw != nil && etag != "" {

--- a/internal/renderer/http_renderer_test.go
+++ b/internal/renderer/http_renderer_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 func TestRenderGetMedia_Cases(t *testing.T) {
 	ctx := context.Background()
-	id := db.NewUUID()
+	id := uuid.NewUUID()
 
 	t.Run("cache hit", func(t *testing.T) {
 		c := &mock.MockCache{Data: []byte(`{"ok":true}`), Etag: "\"1234\""}

--- a/internal/repository/mariadb/media_repository.go
+++ b/internal/repository/mariadb/media_repository.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type MediaRepository struct {
@@ -79,7 +79,7 @@ func (r *MediaRepository) Update(ctx context.Context, media *model.Media) error 
 	return nil
 }
 
-func (r *MediaRepository) GetByID(ctx context.Context, ID db.UUID) (*model.Media, error) {
+func (r *MediaRepository) GetByID(ctx context.Context, ID msuuid.UUID) (*model.Media, error) {
 	log.Printf("fetching media #%s from the database...", ID)
 
 	const query = `
@@ -102,7 +102,7 @@ func (r *MediaRepository) GetByID(ctx context.Context, ID db.UUID) (*model.Media
 	return &media, nil
 }
 
-func (r *MediaRepository) ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]db.UUID, error) {
+func (r *MediaRepository) ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]msuuid.UUID, error) {
 	log.Printf("fetching medias to reoptimise before %s...", before)
 
 	const query = `
@@ -119,9 +119,9 @@ func (r *MediaRepository) ListUnoptimisedCompletedBefore(ctx context.Context, be
 		}
 	}()
 
-	var ids []db.UUID
+	var ids []msuuid.UUID
 	for rows.Next() {
-		var id db.UUID
+		var id msuuid.UUID
 		if err := rows.Scan(&id); err != nil {
 			return nil, err
 		}
@@ -133,7 +133,7 @@ func (r *MediaRepository) ListUnoptimisedCompletedBefore(ctx context.Context, be
 	return ids, nil
 }
 
-func (r *MediaRepository) Delete(ctx context.Context, ID db.UUID) error {
+func (r *MediaRepository) Delete(ctx context.Context, ID msuuid.UUID) error {
 	log.Printf("deleting media #%s from the database...", ID)
 
 	const query = `DELETE FROM medias WHERE id = ?`
@@ -141,7 +141,7 @@ func (r *MediaRepository) Delete(ctx context.Context, ID db.UUID) error {
 	return err
 }
 
-func (r *MediaRepository) ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]db.UUID, error) {
+func (r *MediaRepository) ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]msuuid.UUID, error) {
 	log.Printf("fetching images to resize before %s...", before)
 
 	const query = `
@@ -162,9 +162,9 @@ func (r *MediaRepository) ListOptimisedImagesNoVariantsBefore(ctx context.Contex
 		}
 	}()
 
-	var ids []db.UUID
+	var ids []msuuid.UUID
 	for rows.Next() {
-		var id db.UUID
+		var id msuuid.UUID
 		if err := rows.Scan(&id); err != nil {
 			return nil, err
 		}

--- a/internal/task/dispatcher.go
+++ b/internal/task/dispatcher.go
@@ -3,8 +3,8 @@ package task
 import (
 	"context"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/hibiken/asynq"
 )
 
@@ -20,7 +20,7 @@ func NewDispatcher(addr, password string) *Dispatcher {
 	return &Dispatcher{client: c}
 }
 
-func (d *Dispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error {
+func (d *Dispatcher) EnqueueOptimiseMedia(ctx context.Context, id uuid.UUID) error {
 	t, err := NewOptimiseMediaTask(id.String())
 	if err != nil {
 		return err
@@ -31,7 +31,7 @@ func (d *Dispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error
 	return nil
 }
 
-func (d *Dispatcher) EnqueueResizeImage(ctx context.Context, id db.UUID) error {
+func (d *Dispatcher) EnqueueResizeImage(ctx context.Context, id uuid.UUID) error {
 	t, err := NewResizeImageTask(id.String())
 	if err != nil {
 		return err

--- a/internal/task/noop_dispatcher.go
+++ b/internal/task/noop_dispatcher.go
@@ -3,8 +3,8 @@ package task
 import (
 	"context"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type NoopDispatcher struct{}
@@ -13,10 +13,10 @@ var _ port.TaskDispatcher = (*NoopDispatcher)(nil)
 
 func NewNoopDispatcher() *NoopDispatcher { return &NoopDispatcher{} }
 
-func (d *NoopDispatcher) EnqueueOptimiseMedia(ctx context.Context, id db.UUID) error {
+func (d *NoopDispatcher) EnqueueOptimiseMedia(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (d *NoopDispatcher) EnqueueResizeImage(ctx context.Context, id db.UUID) error {
+func (d *NoopDispatcher) EnqueueResizeImage(ctx context.Context, id uuid.UUID) error {
 	return nil
 }

--- a/internal/usecase/media/delete_media.go
+++ b/internal/usecase/media/delete_media.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"log"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type deleteMediaSrv struct {
@@ -25,7 +25,7 @@ func NewMediaDeleter(repo port.MediaRepository, cache port.Cache, strg port.Stor
 }
 
 // DeleteMedia removes the file from storage, deletes DB record and clears the cache.
-func (s *deleteMediaSrv) DeleteMedia(ctx context.Context, id db.UUID) error {
+func (s *deleteMediaSrv) DeleteMedia(ctx context.Context, id msuuid.UUID) error {
 	media, err := s.repo.GetByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/usecase/media/delete_media_test.go
+++ b/internal/usecase/media/delete_media_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/model"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/google/uuid"
 )
 
@@ -16,7 +16,7 @@ func TestDeleteMedia_NotFound(t *testing.T) {
 	repo := &mock.MockMediaRepo{GetErr: sql.ErrNoRows}
 	svc := NewMediaDeleter(repo, &mock.MockCache{}, &mock.MockStorage{})
 
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	err := svc.DeleteMedia(context.Background(), id)
 	if !errors.Is(err, ErrObjectNotFound) {
 		t.Fatalf("expected ErrObjectNotFound, got %v", err)
@@ -27,14 +27,14 @@ func TestDeleteMedia_GetByIDError(t *testing.T) {
 	repo := &mock.MockMediaRepo{GetErr: errors.New("db fail")}
 	svc := NewMediaDeleter(repo, &mock.MockCache{}, &mock.MockStorage{})
 
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	if err := svc.DeleteMedia(context.Background(), id); err == nil || err.Error() != "db fail" {
 		t.Fatalf("expected db fail, got %v", err)
 	}
 }
 
 func TestDeleteMedia_RemoveError(t *testing.T) {
-	m := &model.Media{ID: db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k"}
+	m := &model.Media{ID: msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k"}
 	repo := &mock.MockMediaRepo{MediaRecord: m}
 	strg := &mock.MockStorage{RemoveErr: errors.New("remove fail")}
 	svc := NewMediaDeleter(repo, &mock.MockCache{}, strg)
@@ -46,7 +46,7 @@ func TestDeleteMedia_RemoveError(t *testing.T) {
 }
 
 func TestDeleteMedia_DeleteError(t *testing.T) {
-	m := &model.Media{ID: db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k"}
+	m := &model.Media{ID: msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k"}
 	repo := &mock.MockMediaRepo{MediaRecord: m, DeleteErr: errors.New("delete fail")}
 	strg := &mock.MockStorage{}
 	svc := NewMediaDeleter(repo, &mock.MockCache{}, strg)
@@ -58,7 +58,7 @@ func TestDeleteMedia_DeleteError(t *testing.T) {
 }
 
 func TestDeleteMedia_Success(t *testing.T) {
-	m := &model.Media{ID: db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k", Variants: model.Variants{{ObjectKey: "v1"}}}
+	m := &model.Media{ID: msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")), Bucket: "images", ObjectKey: "k", Variants: model.Variants{{ObjectKey: "v1"}}}
 	repo := &mock.MockMediaRepo{MediaRecord: m}
 	strg := &mock.MockStorage{}
 	cache := &mock.MockCache{}

--- a/internal/usecase/media/finalise_upload_test.go
+++ b/internal/usecase/media/finalise_upload_test.go
@@ -4,24 +4,24 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
-	"github.com/google/uuid"
 	"image"
 	"image/png"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+	"github.com/google/uuid"
 )
 
 func TestFinaliseUpload_ErrGetByID(t *testing.T) {
 	repo := &mock.MockMediaRepo{GetErr: errors.New("db fail")}
 	svc := NewUploadFinaliser(repo, &mock.MockStorage{}, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || err.Error() != "db fail" {
 		t.Errorf("expected getByID error, got %v", err)
 	}
@@ -32,7 +32,7 @@ func TestFinaliseUpload_AlreadyCompleted(t *testing.T) {
 	repo := &mock.MockMediaRepo{MediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, &mock.MockStorage{}, &mock.MockDispatcher{})
 
-	if err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"}); err != nil {
+	if err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -42,7 +42,7 @@ func TestFinaliseUpload_WrongStatus(t *testing.T) {
 	repo := &mock.MockMediaRepo{MediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, &mock.MockStorage{}, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "media status should be 'pending'") {
 		t.Errorf("expected status error, got %v", err)
 	}
@@ -54,7 +54,7 @@ func TestFinaliseUpload_StatNotFound(t *testing.T) {
 	repo := &mock.MockMediaRepo{MediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, stg, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "staging file \"k\" not found") {
 		t.Errorf("expected not found error, got %v", err)
 	}
@@ -79,7 +79,7 @@ func TestFinaliseUpload_SizeValidation(t *testing.T) {
 		stg := &mock.MockStorage{StatInfo: port.FileInfo{SizeBytes: tc.size, ContentType: "image/png"}}
 		repo := &mock.MockMediaRepo{MediaRecord: mrec}
 		svc := NewUploadFinaliser(repo, stg, &mock.MockDispatcher{})
-		err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+		err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 			t.Errorf("size %d: expected error containing %q, got %v", tc.size, tc.wantErr, err)
 		}
@@ -92,7 +92,7 @@ func TestFinaliseUpload_UnsupportedMime(t *testing.T) {
 	repo := &mock.MockMediaRepo{MediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, stg, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported mime-type") {
 		t.Errorf("expected unsupported mime-type error, got %v", err)
 	}
@@ -104,7 +104,7 @@ func TestFinaliseUpload_MoveGetFileError(t *testing.T) {
 	repo := &mock.MockMediaRepo{MediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, stg, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "can't read file") {
 		t.Errorf("expected getfile error, got %v", err)
 	}
@@ -116,7 +116,7 @@ func TestFinaliseUpload_MoveExtensionError(t *testing.T) {
 	repo := &mock.MockMediaRepo{MediaRecord: mrec}
 	svc := NewUploadFinaliser(repo, stg, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported mime-type") {
 		t.Errorf("expected extension error, got %v", err)
 	}
@@ -128,7 +128,7 @@ func TestFinaliseUpload_MoveMetadataError(t *testing.T) {
 	stg := &mock.MockStorage{StatInfo: port.FileInfo{SizeBytes: MinFileSize, ContentType: "image/png"}, Reader: strings.NewReader("not-a-png")}
 	svc := NewUploadFinaliser(repo, stg, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "error decoding") {
 		t.Errorf("expected metadata error, got %v", err)
 	}
@@ -140,7 +140,7 @@ func TestFinaliseUpload_MoveSaveFileError(t *testing.T) {
 	stg := &mock.MockStorage{SaveErr: errors.New("save fail"), StatInfo: port.FileInfo{SizeBytes: MinFileSize, ContentType: "image/png"}, Reader: getPNGReader(t)}
 	svc := NewUploadFinaliser(repo, stg, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "save fail") {
 		t.Errorf("expected savefile error, got %v", err)
 	}
@@ -152,7 +152,7 @@ func TestFinaliseUpload_MoveUpdateMediaError(t *testing.T) {
 	stg := &mock.MockStorage{StatInfo: port.FileInfo{SizeBytes: MinFileSize, ContentType: "image/png"}, Reader: getPNGReader(t)}
 	svc := NewUploadFinaliser(repo, stg, &mock.MockDispatcher{})
 
-	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"})
+	err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"})
 	if err == nil || !strings.Contains(err.Error(), "update fail") {
 		t.Errorf("expected repo update error, got %v", err)
 	}
@@ -165,7 +165,7 @@ func TestFinaliseUpload_Success(t *testing.T) {
 	dispatcher := &mock.MockDispatcher{}
 	svc := NewUploadFinaliser(repo, stg, dispatcher)
 
-	if err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: db.UUID(uuid.Nil), DestBucket: "images"}); err != nil {
+	if err := svc.FinaliseUpload(context.Background(), port.FinaliseUploadInput{ID: msuuid.UUID(uuid.Nil), DestBucket: "images"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if mrec.Bucket != "images" {

--- a/internal/usecase/media/generate_upload_link_test.go
+++ b/internal/usecase/media/generate_upload_link_test.go
@@ -3,23 +3,23 @@ package media
 import (
 	"context"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
-	"github.com/fhuszti/medias-ms-go/internal/port"
 	"reflect"
 	"testing"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/model"
+	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/google/uuid"
 )
 
 func TestGenerateUploadLink_Success(t *testing.T) {
-	mockID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	mockID := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 
 	repo := &mock.MockMediaRepo{}
 	strg := &mock.MockStorage{}
-	svc := NewUploadLinkGenerator(repo, strg, func() db.UUID { return mockID })
+	svc := NewUploadLinkGenerator(repo, strg, func() msuuid.UUID { return mockID })
 
 	in := port.GenerateUploadLinkInput{Name: "my-file.webp"}
 	out, err := svc.GenerateUploadLink(context.Background(), in)
@@ -73,17 +73,17 @@ func TestGenerateUploadLink_Success(t *testing.T) {
 }
 
 func TestGenerateUploadLink_RepoError(t *testing.T) {
-	mockID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	mockID := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 
 	repo := &mock.MockMediaRepo{CreateErr: errors.New("repo failure")}
 	strg := &mock.MockStorage{}
-	svc := NewUploadLinkGenerator(repo, strg, func() db.UUID { return mockID })
+	svc := NewUploadLinkGenerator(repo, strg, func() msuuid.UUID { return mockID })
 
 	out, err := svc.GenerateUploadLink(context.Background(), port.GenerateUploadLinkInput{Name: "foo"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if out.ID != db.UUID(uuid.Nil) {
+	if out.ID != msuuid.UUID(uuid.Nil) {
 		t.Errorf("expected zero UUID, got %q", out.ID)
 	}
 	if out.URL != "" {
@@ -96,17 +96,17 @@ func TestGenerateUploadLink_RepoError(t *testing.T) {
 }
 
 func TestGenerateUploadLink_StorageError(t *testing.T) {
-	mockID := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	mockID := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 
 	repo := &mock.MockMediaRepo{}
 	strg := &mock.MockStorage{GenerateUploadLinkErr: errors.New("strg failure")}
-	svc := NewUploadLinkGenerator(repo, strg, func() db.UUID { return mockID })
+	svc := NewUploadLinkGenerator(repo, strg, func() msuuid.UUID { return mockID })
 
 	out, err := svc.GenerateUploadLink(context.Background(), port.GenerateUploadLinkInput{Name: "foo"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if out.ID != db.UUID(uuid.Nil) {
+	if out.ID != msuuid.UUID(uuid.Nil) {
 		t.Errorf("expected zero UUID, got %q", out.ID)
 	}
 	if out.URL != "" {

--- a/internal/usecase/media/get_media.go
+++ b/internal/usecase/media/get_media.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 type mediaGetterSrv struct {
@@ -25,7 +25,7 @@ func NewMediaGetter(repo port.MediaRepository, strg port.Storage) port.MediaGett
 	return &mediaGetterSrv{repo: repo, strg: strg}
 }
 
-func (s *mediaGetterSrv) GetMedia(ctx context.Context, id db.UUID) (*port.GetMediaOutput, error) {
+func (s *mediaGetterSrv) GetMedia(ctx context.Context, id msuuid.UUID) (*port.GetMediaOutput, error) {
 	media, err := s.repo.GetByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/usecase/media/get_media_test.go
+++ b/internal/usecase/media/get_media_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/model"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 )
 
 func TestGetMedia_RepoError(t *testing.T) {
@@ -17,7 +17,7 @@ func TestGetMedia_RepoError(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaGetter(repo, strg)
 
-	_, err := svc.GetMedia(context.Background(), db.UUID{})
+	_, err := svc.GetMedia(context.Background(), msuuid.UUID{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -29,7 +29,7 @@ func TestGetMedia_WrongStatus(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaGetter(repo, strg)
 
-	_, err := svc.GetMedia(context.Background(), db.UUID{})
+	_, err := svc.GetMedia(context.Background(), msuuid.UUID{})
 	want := "media status should be 'completed' to be returned"
 	if err == nil || err.Error() != want {
 		t.Fatalf("expected %q, got %v", want, err)
@@ -43,7 +43,7 @@ func TestGetMedia_URLGenError(t *testing.T) {
 	strg := &mock.MockStorage{GenerateDownloadLinkErr: errors.New("link generation failed")}
 	svc := NewMediaGetter(repo, strg)
 
-	_, err := svc.GetMedia(context.Background(), db.UUID{})
+	_, err := svc.GetMedia(context.Background(), msuuid.UUID{})
 	wantPrefix := "error generating presigned download URL"
 	if err == nil || !strings.HasPrefix(err.Error(), wantPrefix) {
 		t.Fatalf("expected error prefix %q, got %v", wantPrefix, err)
@@ -81,7 +81,7 @@ func TestGetMedia_VariantSuccess(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaGetter(repo, strg)
 
-	out, err := svc.GetMedia(context.Background(), db.UUID{})
+	out, err := svc.GetMedia(context.Background(), msuuid.UUID{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/usecase/media/optimise_backlog_test.go
+++ b/internal/usecase/media/optimise_backlog_test.go
@@ -3,10 +3,10 @@ package media
 import (
 	"context"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/google/uuid"
 )
 
@@ -25,11 +25,11 @@ func TestBacklogOptimiser_RepoError(t *testing.T) {
 }
 
 func TestBacklogOptimiser_Success(t *testing.T) {
-	id1 := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
-	id2 := db.UUID(uuid.MustParse("ffffffff-1111-2222-3333-444444444444"))
-	resize1 := db.UUID(uuid.MustParse("11111111-2222-3333-4444-555555555555"))
-	resize2 := db.UUID(uuid.MustParse("66666666-7777-8888-9999-000000000000"))
-	repo := &mock.MockMediaRepo{ListOut: []db.UUID{id1, id2}, ListVariantsOut: []db.UUID{resize1, resize2}}
+	id1 := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id2 := msuuid.UUID(uuid.MustParse("ffffffff-1111-2222-3333-444444444444"))
+	resize1 := msuuid.UUID(uuid.MustParse("11111111-2222-3333-4444-555555555555"))
+	resize2 := msuuid.UUID(uuid.MustParse("66666666-7777-8888-9999-000000000000"))
+	repo := &mock.MockMediaRepo{ListOut: []msuuid.UUID{id1, id2}, ListVariantsOut: []msuuid.UUID{resize1, resize2}}
 	dispatcher := &mock.MockDispatcher{}
 	svc := NewBacklogOptimiser(repo, dispatcher)
 
@@ -54,9 +54,9 @@ func TestBacklogOptimiser_Success(t *testing.T) {
 }
 
 func TestBacklogOptimiser_DispatcherError(t *testing.T) {
-	id1 := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
-	id2 := db.UUID(uuid.MustParse("ffffffff-1111-2222-3333-444444444444"))
-	repo := &mock.MockMediaRepo{ListOut: []db.UUID{id1, id2}}
+	id1 := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id2 := msuuid.UUID(uuid.MustParse("ffffffff-1111-2222-3333-444444444444"))
+	repo := &mock.MockMediaRepo{ListOut: []msuuid.UUID{id1, id2}}
 	dispatcher := &mock.MockDispatcher{OptimiseErr: errors.New("queue fail")}
 	svc := NewBacklogOptimiser(repo, dispatcher)
 
@@ -83,8 +83,8 @@ func TestBacklogOptimiser_ListVariantsError(t *testing.T) {
 }
 
 func TestBacklogOptimiser_ResizeDispatcherError(t *testing.T) {
-	resize1 := db.UUID(uuid.MustParse("11111111-2222-3333-4444-555555555555"))
-	repo := &mock.MockMediaRepo{ListVariantsOut: []db.UUID{resize1}}
+	resize1 := msuuid.UUID(uuid.MustParse("11111111-2222-3333-4444-555555555555"))
+	repo := &mock.MockMediaRepo{ListVariantsOut: []msuuid.UUID{resize1}}
 	dispatcher := &mock.MockDispatcher{ResizeErr: errors.New("queue fail")}
 	svc := NewBacklogOptimiser(repo, dispatcher)
 

--- a/internal/usecase/media/optimise_media.go
+++ b/internal/usecase/media/optimise_media.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"golang.org/x/net/context"
 )
 
@@ -30,7 +30,7 @@ func NewMediaOptimiser(repo port.MediaRepository, opt port.FileOptimiser, strg p
 	return &mediaOptimiserSrv{repo, opt, strg, tasks, cache}
 }
 
-func (m *mediaOptimiserSrv) OptimiseMedia(ctx context.Context, id db.UUID) error {
+func (m *mediaOptimiserSrv) OptimiseMedia(ctx context.Context, id msuuid.UUID) error {
 	media, err := m.repo.GetByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/usecase/media/optimise_media_test.go
+++ b/internal/usecase/media/optimise_media_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"strings"
 	"testing"
 
-	"github.com/fhuszti/medias-ms-go/internal/db"
+	"github.com/fhuszti/medias-ms-go/internal/mock"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/google/uuid"
 )
 
@@ -18,7 +18,7 @@ func newCompletedMedia() *model.Media {
 	mt := "image/png"
 	size := int64(123)
 	return &model.Media{
-		ID:        db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")),
+		ID:        msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")),
 		ObjectKey: "foo.png",
 		Bucket:    "images",
 		MimeType:  &mt,
@@ -32,7 +32,7 @@ func TestOptimiseMedia_GetByIDNotFound(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaOptimiser(repo, &mock.MockFileOptimiser{}, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), db.NewUUID())
+	err := svc.OptimiseMedia(context.Background(), msuuid.NewUUID())
 	if !errors.Is(err, ErrObjectNotFound) {
 		t.Fatalf("expected ErrObjectNotFound, got %v", err)
 	}
@@ -43,7 +43,7 @@ func TestOptimiseMedia_GetByIDError(t *testing.T) {
 	strg := &mock.MockStorage{}
 	svc := NewMediaOptimiser(repo, &mock.MockFileOptimiser{}, strg, &mock.MockDispatcher{}, &mock.MockCache{})
 
-	err := svc.OptimiseMedia(context.Background(), db.NewUUID())
+	err := svc.OptimiseMedia(context.Background(), msuuid.NewUUID())
 	if err == nil || err.Error() != "db fail" {
 		t.Fatalf("expected db error, got %v", err)
 	}

--- a/internal/uuid/uuid.go
+++ b/internal/uuid/uuid.go
@@ -1,0 +1,51 @@
+package uuid
+
+import (
+	"database/sql/driver"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// UUID is a thin wrapper around google's uuid.UUID that implements database
+// scanning and driver.Value interfaces.
+type UUID uuid.UUID
+
+// NewUUID creates a new random UUID.
+func NewUUID() UUID {
+	return UUID(uuid.New())
+}
+
+func (u UUID) String() string {
+	return uuid.UUID(u).String()
+}
+
+func (u *UUID) Scan(src interface{}) error {
+	b, ok := src.([]byte)
+	if !ok {
+		return fmt.Errorf("UUID.Scan: expected []byte, got %T", src)
+	}
+	id, err := uuid.FromBytes(b)
+	if err != nil {
+		return err
+	}
+	*u = UUID(id)
+	return nil
+}
+
+func (u UUID) Value() (driver.Value, error) {
+	return uuid.UUID(u).MarshalBinary()
+}
+
+func (u UUID) MarshalText() ([]byte, error) {
+	return []byte(uuid.UUID(u).String()), nil
+}
+
+func (u *UUID) UnmarshalText(text []byte) error {
+	parsed, err := uuid.ParseBytes(text)
+	if err != nil {
+		return err
+	}
+	*u = UUID(parsed)
+	return nil
+}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -2,11 +2,12 @@ package validation
 
 import (
 	"encoding/json"
-	"github.com/fhuszti/medias-ms-go/internal/db"
-	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
-	"github.com/google/uuid"
 	"reflect"
 	"strings"
+
+	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+	guuid "github.com/google/uuid"
 
 	"github.com/go-playground/validator/v10"
 )
@@ -27,14 +28,14 @@ func init() {
 		return name
 	})
 
-	// Validate db.UUID as string
+	// Validate uuid.UUID as string
 	validate.RegisterCustomTypeFunc(func(field reflect.Value) interface{} {
-		if v, ok := field.Interface().(db.UUID); ok {
-			u := uuid.UUID(v)
+		if v, ok := field.Interface().(msuuid.UUID); ok {
+			u := guuid.UUID(v)
 			return u.String()
 		}
 		return nil
-	}, db.UUID{})
+	}, msuuid.UUID{})
 
 	// Validate mime types
 	err := validate.RegisterValidation("mimetype", func(fl validator.FieldLevel) bool {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -2,9 +2,10 @@ package validation
 
 import (
 	"encoding/json"
-	"github.com/fhuszti/medias-ms-go/internal/db"
-	"github.com/google/uuid"
 	"testing"
+
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+	guuid "github.com/google/uuid"
 )
 
 func TestValidateStructAndErrorsToJson(t *testing.T) {
@@ -73,8 +74,8 @@ func TestValidateStructAndErrorsToJson(t *testing.T) {
 
 func TestCustomTypeValidation(t *testing.T) {
 	type Input struct {
-		ID   db.UUID `validate:"required,uuid4" json:"id"`
-		Type string  `validate:"required,mimetype" json:"type"`
+		ID   msuuid.UUID `validate:"required,uuid4" json:"id"`
+		Type string      `validate:"required,mimetype" json:"type"`
 	}
 
 	tests := []struct {
@@ -85,12 +86,12 @@ func TestCustomTypeValidation(t *testing.T) {
 	}{
 		{
 			name:    "all good",
-			in:      Input{ID: db.UUID(uuid.New()), Type: "text/markdown"},
+			in:      Input{ID: msuuid.UUID(guuid.New()), Type: "text/markdown"},
 			wantErr: false,
 		},
 		{
 			name:    "bad uuid, bad mimetype",
-			in:      Input{ID: db.UUID(uuid.Nil), Type: "application/x-foo"},
+			in:      Input{ID: msuuid.UUID(guuid.Nil), Type: "application/x-foo"},
 			wantErr: true,
 			wantErrMap: map[string]string{
 				"id":   "uuid4",

--- a/test/e2e/upload_pdf_test.go
+++ b/test/e2e/upload_pdf_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	"github.com/fhuszti/medias-ms-go/internal/task"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/test/testutil"
 	"github.com/go-chi/chi/v5"
 )
@@ -74,7 +75,7 @@ func setupServer(t *testing.T) *httptest.Server {
 
 	// Initialize repo and services
 	repo := mariadb.NewMediaRepository(dbConn)
-	uploadLinkSvc := mediaSvc.NewUploadLinkGenerator(repo, GlobalStrg, db.NewUUID)
+	uploadLinkSvc := mediaSvc.NewUploadLinkGenerator(repo, GlobalStrg, msuuid.NewUUID)
 	finaliserSvc := mediaSvc.NewUploadFinaliser(repo, GlobalStrg, task.NewDispatcher(RedisAddr, ""))
 	workerStop := testutil.StartWorker(&db.Database{dbConn}, GlobalStrg, RedisAddr)
 	t.Cleanup(workerStop)

--- a/test/integration/delete_media_test.go
+++ b/test/integration/delete_media_test.go
@@ -14,12 +14,12 @@ import (
 	"testing"
 
 	"github.com/fhuszti/medias-ms-go/internal/cache"
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/handler/api"
 	"github.com/fhuszti/medias-ms-go/internal/migration"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/test/testutil"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -58,7 +58,7 @@ func TestDeleteMediaIntegration_Success(t *testing.T) {
 	repo, svc, cleanup := setupMediaDeleter(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	objectKey := id.String() + ".png"
 	bucket := "images"
 

--- a/test/integration/finalise_upload_test.go
+++ b/test/integration/finalise_upload_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/handler/api"
 	"github.com/fhuszti/medias-ms-go/internal/migration"
 	"github.com/fhuszti/medias-ms-go/internal/model"
@@ -12,6 +11,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	"github.com/fhuszti/medias-ms-go/internal/task"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/test/testutil"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -57,7 +57,7 @@ func TestFinaliseUploadIntegration_SuccessMarkdown(t *testing.T) {
 	defer cleanup()
 
 	// Prepare media record and staging file
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	objectKey := id.String()
 	destObjectKey := objectKey + ".md"
 	content := testutil.GenerateMarkdown()
@@ -143,7 +143,7 @@ func TestFinaliseUploadIntegration_SuccessImage(t *testing.T) {
 	defer cleanup()
 
 	// Prepare a media record and staging file (PNG)
-	id := db.UUID(uuid.MustParse("bbbbbbbb-cccc-dddd-eeee-ffffffffffff"))
+	id := msuuid.UUID(uuid.MustParse("bbbbbbbb-cccc-dddd-eeee-ffffffffffff"))
 	objectKey := id.String()
 	destObjectKey := objectKey + ".png"
 
@@ -243,7 +243,7 @@ func TestFinaliseUploadIntegration_SuccessPDF(t *testing.T) {
 	defer cleanup()
 
 	// Prepare media record and a staging file (PDF)
-	id := db.UUID(uuid.MustParse("cccccccc-dddd-eeee-ffff-000000000000"))
+	id := msuuid.UUID(uuid.MustParse("cccccccc-dddd-eeee-ffff-000000000000"))
 	objectKey := id.String()
 	destObjectKey := objectKey + ".pdf"
 
@@ -339,7 +339,7 @@ func TestFinaliseUploadIntegration_Idempotency(t *testing.T) {
 	defer cleanup()
 
 	// Prepare a Markdown payload in staging
-	id := db.UUID(uuid.MustParse("dddddddd-eeee-ffff-0000-111111111111"))
+	id := msuuid.UUID(uuid.MustParse("dddddddd-eeee-ffff-0000-111111111111"))
 	objectKey := id.String()
 	destObjectKey := objectKey + ".md"
 	content := testutil.GenerateMarkdown()
@@ -429,7 +429,7 @@ func TestFinaliseUploadIntegration_ErrorFileSize(t *testing.T) {
 	defer cleanup()
 
 	// Prepare an undersized Markdown file
-	id := db.UUID(uuid.MustParse("eeeeeeee-ffff-0000-1111-222222222222"))
+	id := msuuid.UUID(uuid.MustParse("eeeeeeee-ffff-0000-1111-222222222222"))
 	objectKey := id.String()
 	destObjectKey := objectKey + ".md"
 	// content length = MinFileSize - 1

--- a/test/integration/generate_upload_link_test.go
+++ b/test/integration/generate_upload_link_test.go
@@ -3,13 +3,13 @@ package integration
 import (
 	"context"
 	"encoding/json"
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/handler/api"
 	"github.com/fhuszti/medias-ms-go/internal/migration"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	mediaService "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/test/testutil"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -40,7 +40,7 @@ func TestGenerateUploadLinkIntegration_Success(t *testing.T) {
 	defer bCleanup()
 
 	mediaRepo := mariadb.NewMediaRepository(database)
-	svc := mediaService.NewUploadLinkGenerator(mediaRepo, GlobalStrg, db.NewUUID)
+	svc := mediaService.NewUploadLinkGenerator(mediaRepo, GlobalStrg, msuuid.NewUUID)
 
 	in := port.GenerateUploadLinkInput{
 		Name: "file_example.png",
@@ -51,7 +51,7 @@ func TestGenerateUploadLinkIntegration_Success(t *testing.T) {
 		t.Fatalf("GenerateUploadLink returned error: %v", err)
 	}
 
-	if out.ID == db.UUID(uuid.Nil) {
+	if out.ID == msuuid.UUID(uuid.Nil) {
 		t.Fatal("expected non-empty ID")
 	}
 
@@ -75,7 +75,7 @@ func TestGenerateUploadLinkIntegration_Success(t *testing.T) {
 	}
 
 	var (
-		id               db.UUID
+		id               msuuid.UUID
 		bucket           string
 		originalFilename string
 		status           model.MediaStatus

--- a/test/integration/get_media_test.go
+++ b/test/integration/get_media_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/handler/api"
 	"github.com/fhuszti/medias-ms-go/internal/migration"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/test/testutil"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -55,7 +55,7 @@ func TestGetMediaIntegration_SuccessMarkdown(t *testing.T) {
 	mediaRepo, svc, cleanup := setupMediaGetter(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	objectKey := id.String() + ".md"
 	bucket := "docs"
 	content := testutil.GenerateMarkdown()
@@ -123,7 +123,7 @@ func TestGetMediaIntegration_SuccessPDF(t *testing.T) {
 	mediaRepo, svc, cleanup := setupMediaGetter(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	objectKey := id.String() + ".md"
 	bucket := "docs"
 	content := testutil.LoadPDF(t)
@@ -185,7 +185,7 @@ func TestGetMediaIntegration_SuccessImageWithVariants(t *testing.T) {
 	mediaRepo, svc, cleanup := setupMediaGetter(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+	id := msuuid.UUID(uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 	objectKey := id.String() + ".png"
 	bucket := "images"
 

--- a/test/integration/optimise_task_test.go
+++ b/test/integration/optimise_task_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	"github.com/fhuszti/medias-ms-go/internal/task"
+	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/test/testutil"
 	"github.com/google/uuid"
 )
@@ -45,7 +46,7 @@ func setupWorker(t *testing.T) (*mariadb.MediaRepository, func()) {
 	return repo, cleanup
 }
 
-func waitOptimised(t *testing.T, repo *mariadb.MediaRepository, id db.UUID, wantVariants bool) *model.Media {
+func waitOptimised(t *testing.T, repo *mariadb.MediaRepository, id msuuid.UUID, wantVariants bool) *model.Media {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
 	for {
@@ -69,7 +70,7 @@ func TestOptimiseTaskIntegration_SuccessPNG(t *testing.T) {
 	repo, cleanup := setupWorker(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("11111111-1111-1111-1111-111111111111"))
+	id := msuuid.UUID(uuid.MustParse("11111111-1111-1111-1111-111111111111"))
 	objectKey := id.String() + ".png"
 	width, height := 200, 100
 	content := testutil.GeneratePNG(t, width, height)
@@ -156,7 +157,7 @@ func TestOptimiseTaskIntegration_SuccessWEBP(t *testing.T) {
 	repo, cleanup := setupWorker(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("22222222-2222-2222-2222-222222222222"))
+	id := msuuid.UUID(uuid.MustParse("22222222-2222-2222-2222-222222222222"))
 	objectKey := id.String() + ".webp"
 	width, height := 200, 400
 	content := testutil.GenerateWebP(t, width, height)
@@ -223,7 +224,7 @@ func TestOptimiseTaskIntegration_SuccessPDF(t *testing.T) {
 	repo, cleanup := setupWorker(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("33333333-3333-3333-3333-333333333333"))
+	id := msuuid.UUID(uuid.MustParse("33333333-3333-3333-3333-333333333333"))
 	objectKey := id.String() + ".pdf"
 	content := testutil.LoadPDF(t)
 	size := int64(len(content))
@@ -259,7 +260,7 @@ func TestOptimiseTaskIntegration_SuccessMarkdown(t *testing.T) {
 	repo, cleanup := setupWorker(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("44444444-4444-4444-4444-444444444444"))
+	id := msuuid.UUID(uuid.MustParse("44444444-4444-4444-4444-444444444444"))
 	objectKey := id.String() + ".md"
 	content := testutil.GenerateMarkdown()
 	size := int64(len(content))
@@ -295,7 +296,7 @@ func TestOptimiseTaskIntegration_ErrorWrongStatus(t *testing.T) {
 	repo, cleanup := setupWorker(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("55555555-5555-5555-5555-555555555555"))
+	id := msuuid.UUID(uuid.MustParse("55555555-5555-5555-5555-555555555555"))
 	objectKey := id.String() + ".png"
 	content := testutil.GeneratePNG(t, 10, 10)
 	size := int64(len(content))
@@ -330,7 +331,7 @@ func TestOptimiseTaskIntegration_ErrorMissingFile(t *testing.T) {
 	repo, cleanup := setupWorker(t)
 	defer cleanup()
 
-	id := db.UUID(uuid.MustParse("66666666-6666-6666-6666-666666666666"))
+	id := msuuid.UUID(uuid.MustParse("66666666-6666-6666-6666-666666666666"))
 	objectKey := id.String() + ".png"
 	size := int64(100)
 	mime := "image/png"


### PR DESCRIPTION
## Summary
- create new internal/uuid package with DB-aware UUID implementation
- update domain and repository code to use uuid.UUID instead of db.UUID
- adjust imports and tests for new package

## Testing
- `make clean`
- `make test` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_686e3a81008483218d4c5dd1afab5685