### PR TITLE
Use renderer in GetMediaHandler

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/db"
 	"github.com/fhuszti/medias-ms-go/internal/handler/api"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/renderer"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	"github.com/fhuszti/medias-ms-go/internal/storage"
 	"github.com/fhuszti/medias-ms-go/internal/task"
@@ -60,8 +61,9 @@ func main() {
 		Post("/medias/finalise_upload/{id}", api.FinaliseUploadHandler(uploadFinaliserSvc, cfg.Buckets))
 
 	getMediaSvc := mediaSvc.NewMediaGetter(mediaRepo, strg)
+	rendererSvc := renderer.NewHTTPRenderer(ca)
 	r.With(api.WithID()).
-		Get("/medias/{id}", api.GetMediaHandler(getMediaSvc))
+		Get("/medias/{id}", api.GetMediaHandler(rendererSvc, getMediaSvc))
 
 	deleteMediaSvc := mediaSvc.NewMediaDeleter(mediaRepo, ca, strg)
 	r.With(api.WithID()).

--- a/internal/mock/http_renderer.go
+++ b/internal/mock/http_renderer.go
@@ -1,0 +1,26 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/uuid"
+)
+
+// MockHTTPRenderer implements port.HTTPRenderer for tests.
+type MockHTTPRenderer struct {
+	Data []byte
+	Etag string
+	Err  error
+
+	Called bool
+	Getter port.MediaGetter
+	ID     uuid.UUID
+}
+
+func (m *MockHTTPRenderer) RenderGetMedia(ctx context.Context, getter port.MediaGetter, id uuid.UUID) ([]byte, string, error) {
+	m.Called = true
+	m.Getter = getter
+	m.ID = id
+	return m.Data, m.Etag, m.Err
+}

--- a/test/e2e/upload_pdf_test.go
+++ b/test/e2e/upload_pdf_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/handler/api"
 	"github.com/fhuszti/medias-ms-go/internal/migration"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/renderer"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	"github.com/fhuszti/medias-ms-go/internal/task"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
@@ -82,6 +83,7 @@ func setupServer(t *testing.T) *httptest.Server {
 	ca := cache.NewNoop()
 	getterSvc := mediaSvc.NewMediaGetter(repo, GlobalStrg)
 	deleterSvc := mediaSvc.NewMediaDeleter(repo, ca, GlobalStrg)
+	rendererSvc := renderer.NewHTTPRenderer(ca)
 
 	// Setup HTTP handlers
 	r := chi.NewRouter()
@@ -89,7 +91,7 @@ func setupServer(t *testing.T) *httptest.Server {
 	r.With(api.WithID()).
 		Post("/medias/finalise_upload/{id}", api.FinaliseUploadHandler(finaliserSvc, []string{"staging", "images", "docs"}))
 	r.With(api.WithID()).
-		Get("/medias/{id}", api.GetMediaHandler(getterSvc))
+		Get("/medias/{id}", api.GetMediaHandler(rendererSvc, getterSvc))
 	r.With(api.WithID()).
 		Delete("/medias/{id}", api.DeleteMediaHandler(deleterSvc))
 

--- a/test/integration/get_media_test.go
+++ b/test/integration/get_media_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/fhuszti/medias-ms-go/internal/cache"
 	"github.com/fhuszti/medias-ms-go/internal/handler/api"
 	"github.com/fhuszti/medias-ms-go/internal/migration"
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+	"github.com/fhuszti/medias-ms-go/internal/renderer"
 	"github.com/fhuszti/medias-ms-go/internal/repository/mariadb"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
@@ -292,7 +294,8 @@ func TestGetMediaIntegration_ErrorNotFound(t *testing.T) {
 	defer cleanup()
 
 	r := chi.NewRouter()
-	r.With(api.WithID()).Get("/medias/{id}", api.GetMediaHandler(svc))
+	rendererSvc := renderer.NewHTTPRenderer(cache.NewNoop())
+	r.With(api.WithID()).Get("/medias/{id}", api.GetMediaHandler(rendererSvc, svc))
 
 	// Make request for a non-existent UUID
 	id := uuid.NewString()
@@ -325,7 +328,8 @@ func TestGetMediaIntegration_ErrorInvalidID(t *testing.T) {
 	svc := mediaSvc.NewMediaGetter(repo, nil)
 
 	r := chi.NewRouter()
-	r.With(api.WithID()).Get("/medias/{id}", api.GetMediaHandler(svc))
+	rendererSvc := renderer.NewHTTPRenderer(cache.NewNoop())
+	r.With(api.WithID()).Get("/medias/{id}", api.GetMediaHandler(rendererSvc, svc))
 
 	// Invalid UUID
 	req := httptest.NewRequest(http.MethodGet, "/medias/not-a-uuid", nil)


### PR DESCRIPTION
## Summary
- use the `HTTPRenderer` in `GetMediaHandler`
- return 5min cache control header for media fetches
- wire renderer in the API setup
- add a mock renderer for tests
- update unit, integration and e2e tests
- log when returning cached media via ETag

## Testing
- `make clean`
- `go test ./...`
- `go test ./...` in `test/e2e` *(fails: could not start mariadb container)*
- `go test ./...` in `test/integration` *(fails: could not start mariadb container)*

------
https://chatgpt.com/codex/tasks/task_e_686e64e30e6c8321967c1c6897df367b