### PR TITLE
chore: adopt unified logger wrappers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,8 @@
 package config
 
 import (
+	"context"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -10,6 +10,8 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/spf13/viper"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type Settings struct {
@@ -30,10 +32,12 @@ type Settings struct {
 }
 
 func Load() (*Settings, error) {
-	log.Println("loading env variables...")
+	ctx := context.Background()
+
+	logger.Info(ctx, "loading env variables...")
 
 	if err := godotenv.Load(".env"); err != nil {
-		log.Println("No .env file found; proceeding with OS environment variables")
+		logger.Info(ctx, "No .env file found; proceeding with OS environment variables")
 	}
 
 	viper.AutomaticEnv()
@@ -42,7 +46,7 @@ func Load() (*Settings, error) {
 	viper.SetConfigType("env")
 
 	if err := viper.ReadInConfig(); err != nil {
-		log.Printf("Warning: could not read .env file: %v", err)
+		logger.Warnf(ctx, "Warning: could not read .env file: %v", err)
 	}
 
 	if !viper.IsSet("MARIADB_DSN") {
@@ -127,6 +131,7 @@ func getBuckets() []string {
 }
 
 func getImagesSizes() []int {
+	ctx := context.Background()
 	sizes := make([]int, 0)
 	for _, size := range strings.Split(viper.GetString("IMAGES_SIZES"), ",") {
 		size = strings.TrimSpace(size)
@@ -135,7 +140,7 @@ func getImagesSizes() []int {
 		}
 		sizeInt, err := strconv.Atoi(size)
 		if err != nil {
-			log.Printf("Warning: could not parse image size %q: %v", size, err)
+			logger.Warnf(ctx, "Warning: could not parse image size %q: %v", size, err)
 			continue
 		}
 		sizes = append(sizes, sizeInt)

--- a/internal/handler/api/delete_media.go
+++ b/internal/handler/api/delete_media.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"errors"
-	"log"
 	"net/http"
 
 	"github.com/fhuszti/medias-ms-go/internal/api_context"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 // DeleteMediaHandler deletes a media by ID.
@@ -29,6 +30,6 @@ func DeleteMediaHandler(svc port.MediaDeleter) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusNoContent)
-		log.Printf("✅  Successfully deleted media #%s", id)
+		logger.Infof(r.Context(), "✅  Successfully deleted media #%s", id)
 	}
 }

--- a/internal/handler/api/finalise_upload.go
+++ b/internal/handler/api/finalise_upload.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/fhuszti/medias-ms-go/internal/api_context"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/fhuszti/medias-ms-go/internal/validation"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type FinaliseUploadRequest struct {
@@ -43,7 +44,7 @@ func FinaliseUploadHandler(svc port.UploadFinaliser, allowedBuckets []string) ht
 				return
 			}
 			RespondRawJSON(w, http.StatusBadRequest, []byte(errsJSON))
-			log.Printf("❌  Validation failed: %s", errsJSON)
+			logger.Warnf(r.Context(), "❌  Validation failed: %s", errsJSON)
 			return
 		}
 
@@ -66,6 +67,6 @@ func FinaliseUploadHandler(svc port.UploadFinaliser, allowedBuckets []string) ht
 		}
 
 		w.WriteHeader(http.StatusNoContent)
-		log.Printf("✅  Successfully finalised upload of media #%s", input.ID)
+		logger.Infof(r.Context(), "✅  Successfully finalised upload of media #%s", input.ID)
 	}
 }

--- a/internal/handler/api/get_media.go
+++ b/internal/handler/api/get_media.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"errors"
-	"log"
 	"net/http"
 
 	"github.com/fhuszti/medias-ms-go/internal/api_context"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 func GetMediaHandler(renderer port.HTTPRenderer, svc port.MediaGetter) http.HandlerFunc {
@@ -32,11 +33,11 @@ func GetMediaHandler(renderer port.HTTPRenderer, svc port.MediaGetter) http.Hand
 		w.Header().Set("Cache-Control", "public, max-age=300")
 		if match := r.Header.Get("If-None-Match"); match == etag {
 			w.WriteHeader(http.StatusNotModified)
-			log.Printf("✅  Returning cached media #%s", id)
+			logger.Infof(r.Context(), "✅  Returning cached media #%s", id)
 			return
 		}
 
 		RespondRawJSON(w, http.StatusOK, raw)
-		log.Printf("✅  Successfully returned details for media #%s", id)
+		logger.Infof(r.Context(), "✅  Successfully returned details for media #%s", id)
 	}
 }

--- a/internal/handler/api/get_upload_link.go
+++ b/internal/handler/api/get_upload_link.go
@@ -3,11 +3,12 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/validation"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type GenerateUploadLinkRequest struct {
@@ -31,7 +32,7 @@ func GenerateUploadLinkHandler(svc port.UploadLinkGenerator) http.HandlerFunc {
 
 			// return the validation errors payload directly
 			RespondRawJSON(w, http.StatusBadRequest, []byte(errsJSON))
-			log.Printf("❌  Validation failed: %s", errsJSON)
+			logger.Warnf(r.Context(), "❌  Validation failed: %s", errsJSON)
 			return
 		}
 
@@ -43,6 +44,6 @@ func GenerateUploadLinkHandler(svc port.UploadLinkGenerator) http.HandlerFunc {
 		}
 
 		RespondJSON(w, http.StatusCreated, out)
-		log.Printf("✅  Successfully generated upload link for media #%s", out.ID)
+		logger.Infof(r.Context(), "✅  Successfully generated upload link for media #%s", out.ID)
 	}
 }

--- a/internal/handler/api/util.go
+++ b/internal/handler/api/util.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
-	"log"
 	"net/http"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type ErrorResponse struct {
@@ -11,10 +13,11 @@ type ErrorResponse struct {
 }
 
 func WriteError(w http.ResponseWriter, status int, msg string, err error) {
+	ctx := context.Background()
 	if err != nil {
-		log.Printf("❌  %s: %v", msg, err)
+		logger.Errorf(ctx, "❌  %s: %v", msg, err)
 	} else {
-		log.Printf("❌  %s", msg)
+		logger.Error(ctx, "❌  "+msg)
 	}
 	w.Header().Set("Cache-Control", "no-store, max-age=0, must-revalidate")
 	RespondJSON(w, status, ErrorResponse{Error: msg})
@@ -24,7 +27,7 @@ func RespondJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		log.Printf("❌  Failed to encode JSON response: %v", err)
+		logger.Errorf(context.Background(), "❌  Failed to encode JSON response: %v", err)
 	}
 }
 
@@ -32,6 +35,6 @@ func RespondRawJSON(w http.ResponseWriter, status int, raw []byte) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if _, err := w.Write(raw); err != nil {
-		log.Printf("❌  Failed to write JSON payload: %v", err)
+		logger.Errorf(context.Background(), "❌  Failed to write JSON payload: %v", err)
 	}
 }

--- a/internal/handler/worker/optimise_media.go
+++ b/internal/handler/worker/optimise_media.go
@@ -2,13 +2,14 @@ package worker
 
 import (
 	"context"
-	"log"
 
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/task"
 	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/internal/validation"
 	"github.com/google/uuid"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 // OptimiseMediaHandler handles an optimise-media task.
@@ -16,17 +17,17 @@ import (
 // the MediaOptimiser service and delegates the call.
 func OptimiseMediaHandler(ctx context.Context, p task.OptimiseMediaPayload, svc port.MediaOptimiser) error {
 	if err := validation.ValidateStruct(p); err != nil {
-		log.Printf("❌  Payload validation failed: %v", err)
+		logger.Errorf(ctx, "❌  Payload validation failed: %v", err)
 		return err
 	}
 
 	id := uuid.MustParse(p.ID)
 
 	if err := svc.OptimiseMedia(ctx, msuuid.UUID(id)); err != nil {
-		log.Printf("❌  Failed to optimise media #%s: %v", id, err)
+		logger.Errorf(ctx, "❌  Failed to optimise media #%s: %v", id, err)
 		return err
 	}
 
-	log.Printf("✅  Successfully optimised media #%s", id)
+	logger.Infof(ctx, "✅  Successfully optimised media #%s", id)
 	return nil
 }

--- a/internal/handler/worker/resize_image.go
+++ b/internal/handler/worker/resize_image.go
@@ -2,30 +2,31 @@ package worker
 
 import (
 	"context"
-	"log"
 
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/task"
 	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
 	"github.com/fhuszti/medias-ms-go/internal/validation"
 	"github.com/google/uuid"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 // ResizeImageHandler handles a resize-image task.
 // It validates the incoming payload and delegates the call to the service.
 func ResizeImageHandler(ctx context.Context, p task.ResizeImagePayload, sizes []int, svc port.ImageResizer) error {
 	if err := validation.ValidateStruct(p); err != nil {
-		log.Printf("❌  Payload validation failed: %v", err)
+		logger.Errorf(ctx, "❌  Payload validation failed: %v", err)
 		return err
 	}
 
 	id := uuid.MustParse(p.ID)
 	in := port.ResizeImageInput{ID: msuuid.UUID(id), Sizes: sizes}
 	if err := svc.ResizeImage(ctx, in); err != nil {
-		log.Printf("❌  Failed to resize image #%s: %v", id, err)
+		logger.Errorf(ctx, "❌  Failed to resize image #%s: %v", id, err)
 		return err
 	}
 
-	log.Printf("✅  Successfully resized image #%s", id)
+	logger.Infof(ctx, "✅  Successfully resized image #%s", id)
 	return nil
 }

--- a/internal/migration/up.go
+++ b/internal/migration/up.go
@@ -1,11 +1,11 @@
 package migration
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -13,12 +13,15 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/mysql"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 //go:embed migrations/*.sql
 var migrationsFS embed.FS
 
 func MigrateUp(db *sql.DB) error {
+	ctx := context.Background()
 	src, err := iofs.New(migrationsFS, "migrations")
 	if err != nil {
 		return fmt.Errorf("could not create source driver: %v", err)
@@ -43,7 +46,7 @@ func MigrateUp(db *sql.DB) error {
 			if err != nil {
 				return err
 			}
-			log.Printf("database dirty at version %d, forcing back to %d", dirtyErr.Version, prev)
+			logger.Warnf(ctx, "database dirty at version %d, forcing back to %d", dirtyErr.Version, prev)
 			if ferr := m.Force(int(prev)); ferr != nil {
 				return fmt.Errorf("failed to force to version %d: %w", prev, ferr)
 			}

--- a/internal/optimiser/optimiser.go
+++ b/internal/optimiser/optimiser.go
@@ -1,18 +1,20 @@
 package optimiser
 
 import (
+	"context"
 	"fmt"
 	"image"
 	_ "image/jpeg"
 	_ "image/png"
 	"io"
-	"log"
 	"os"
 
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"golang.org/x/image/draw"
 	_ "golang.org/x/image/webp"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type FileOptimiser struct {
@@ -24,7 +26,7 @@ type FileOptimiser struct {
 var _ port.FileOptimiser = (*FileOptimiser)(nil)
 
 func NewFileOptimiser(webpEnc WebPEncoder, pdfOpt PDFOptimizer) *FileOptimiser {
-	log.Println("initialising file optimiser...")
+	logger.Info(context.Background(), "initialising file optimiser...")
 	return &FileOptimiser{
 		webpEnc: webpEnc,
 		pdfOpt:  pdfOpt,
@@ -37,7 +39,7 @@ func NewFileOptimiser(webpEnc WebPEncoder, pdfOpt PDFOptimizer) *FileOptimiser {
 //   - PDFs (application/pdf): run pdfcpu.Optimize to strip unused objects.
 //   - Everything else (e.g. markdown): read as-is and return raw bytes.
 func (fo *FileOptimiser) Compress(mimeType string, r io.Reader) (io.ReadCloser, string, error) {
-	log.Printf("compressing  file of type %q...", mimeType)
+	logger.Debugf(context.Background(), "compressing  file of type %q...", mimeType)
 
 	pr, pw := io.Pipe()
 
@@ -128,7 +130,7 @@ func (fo *FileOptimiser) Compress(mimeType string, r io.Reader) (io.ReadCloser, 
 }
 
 func (fo *FileOptimiser) Resize(mimeType string, r io.Reader, width, height int) (io.ReadCloser, error) {
-	log.Printf("resizing image of type %q...", mimeType)
+	logger.Debugf(context.Background(), "resizing image of type %q...", mimeType)
 
 	pr, pw := io.Pipe()
 

--- a/internal/renderer/http_renderer.go
+++ b/internal/renderer/http_renderer.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
-	"log"
 
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	"github.com/fhuszti/medias-ms-go/internal/uuid"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type httpRenderer struct {
@@ -29,7 +30,7 @@ func (r *httpRenderer) RenderGetMedia(ctx context.Context, getter port.MediaGett
 	raw, err := r.cache.GetMediaDetails(ctx, id)
 	etag, errEtag := r.cache.GetEtagMediaDetails(ctx, id)
 	if err == nil && errEtag == nil && raw != nil && etag != "" {
-		log.Printf("http renderer used the cache to return details for media #%s", id)
+		logger.Infof(ctx, "http renderer used the cache to return details for media #%s", id)
 		return raw, etag, nil
 	}
 

--- a/internal/repository/mariadb/media_repository.go
+++ b/internal/repository/mariadb/media_repository.go
@@ -3,12 +3,13 @@ package mariadb
 import (
 	"context"
 	"database/sql"
-	"log"
 	"time"
 
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type MediaRepository struct {
@@ -23,7 +24,7 @@ func NewMediaRepository(db *sql.DB) *MediaRepository {
 }
 
 func (r *MediaRepository) GetByID(ctx context.Context, ID msuuid.UUID) (*model.Media, error) {
-	log.Printf("fetching media #%s from the database...", ID)
+	logger.Debugf(ctx, "fetching media #%s from the database...", ID)
 
 	const query = `
       SELECT id, object_key, bucket, original_filename, mime_type, size_bytes, status, optimised, failure_message, metadata, variants, created_at, updated_at
@@ -46,7 +47,7 @@ func (r *MediaRepository) GetByID(ctx context.Context, ID msuuid.UUID) (*model.M
 }
 
 func (r *MediaRepository) Create(ctx context.Context, media *model.Media) error {
-	log.Printf("creating database record for media #%s, at status %q...", media.ID, media.Status)
+	logger.Debugf(ctx, "creating database record for media #%s, at status %q...", media.ID, media.Status)
 
 	const query = `
       INSERT INTO medias 
@@ -67,7 +68,7 @@ func (r *MediaRepository) Create(ctx context.Context, media *model.Media) error 
 }
 
 func (r *MediaRepository) Update(ctx context.Context, media *model.Media) error {
-	log.Printf("updating database record for media #%s, with status %q...", media.ID, media.Status)
+	logger.Debugf(ctx, "updating database record for media #%s, with status %q...", media.ID, media.Status)
 
 	const query = `
       UPDATE medias
@@ -103,7 +104,7 @@ func (r *MediaRepository) Update(ctx context.Context, media *model.Media) error 
 }
 
 func (r *MediaRepository) Delete(ctx context.Context, ID msuuid.UUID) error {
-	log.Printf("deleting media #%s from the database...", ID)
+	logger.Debugf(ctx, "deleting media #%s from the database...", ID)
 
 	const query = `DELETE FROM medias WHERE id = ?`
 	_, err := r.db.ExecContext(ctx, query, ID)
@@ -111,7 +112,7 @@ func (r *MediaRepository) Delete(ctx context.Context, ID msuuid.UUID) error {
 }
 
 func (r *MediaRepository) ListUnoptimisedCompletedBefore(ctx context.Context, before time.Time) ([]msuuid.UUID, error) {
-	log.Printf("fetching medias to reoptimise before %s...", before)
+	logger.Debugf(ctx, "fetching medias to reoptimise before %s...", before)
 
 	const query = `
       SELECT id FROM medias
@@ -123,7 +124,7 @@ func (r *MediaRepository) ListUnoptimisedCompletedBefore(ctx context.Context, be
 	}
 	defer func() {
 		if cerr := rows.Close(); cerr != nil {
-			log.Printf("rows close error: %v", cerr)
+			logger.Warnf(ctx, "rows close error: %v", cerr)
 		}
 	}()
 
@@ -142,7 +143,7 @@ func (r *MediaRepository) ListUnoptimisedCompletedBefore(ctx context.Context, be
 }
 
 func (r *MediaRepository) ListOptimisedImagesNoVariantsBefore(ctx context.Context, before time.Time) ([]msuuid.UUID, error) {
-	log.Printf("fetching images to resize before %s...", before)
+	logger.Debugf(ctx, "fetching images to resize before %s...", before)
 
 	const query = `
       SELECT id FROM medias
@@ -158,7 +159,7 @@ func (r *MediaRepository) ListOptimisedImagesNoVariantsBefore(ctx context.Contex
 	}
 	defer func() {
 		if cerr := rows.Close(); cerr != nil {
-			log.Printf("rows close error: %v", cerr)
+			logger.Warnf(ctx, "rows close error: %v", cerr)
 		}
 	}()
 

--- a/internal/storage/minio_storage.go
+++ b/internal/storage/minio_storage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
 	"net/url"
 	"time"
 
@@ -12,6 +11,8 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type Strg struct {
@@ -22,7 +23,7 @@ type Strg struct {
 var _ port.Storage = (*Strg)(nil)
 
 func NewStorage(endpoint, accessKey, secretKey string, useSSL bool) (*Strg, error) {
-	log.Println("initialising minio client...")
+	logger.Info(context.Background(), "initialising minio client...")
 	client, err := minio.New(endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
 		Secure: useSSL,
@@ -39,7 +40,7 @@ func (s *Strg) InitBucket(bucket string) error {
 		return mapMinioErr(err)
 	}
 	if !ok {
-		log.Printf("bucket %q does not exist, creating it...", bucket)
+		logger.Infof(context.Background(), "bucket %q does not exist, creating it...", bucket)
 		if err := s.Client.MakeBucket(context.Background(), bucket, minio.MakeBucketOptions{}); err != nil {
 			return mapMinioErr(err)
 		}
@@ -48,7 +49,7 @@ func (s *Strg) InitBucket(bucket string) error {
 }
 
 func (s *Strg) GeneratePresignedDownloadURL(ctx context.Context, bucket, fileKey string, expiry time.Duration) (string, error) {
-	log.Printf("generating a presigned download link for file %q in bucket %q...", fileKey, bucket)
+	logger.Debugf(ctx, "generating a presigned download link for file %q in bucket %q...", fileKey, bucket)
 
 	presignedURL, err := s.Client.PresignedGetObject(ctx, bucket, fileKey, expiry, url.Values{})
 	if err != nil {
@@ -59,7 +60,7 @@ func (s *Strg) GeneratePresignedDownloadURL(ctx context.Context, bucket, fileKey
 }
 
 func (s *Strg) GeneratePresignedUploadURL(ctx context.Context, bucket, fileKey string, expiry time.Duration) (string, error) {
-	log.Printf("generating a presigned upload link for file %q in bucket %q...", fileKey, bucket)
+	logger.Debugf(ctx, "generating a presigned upload link for file %q in bucket %q...", fileKey, bucket)
 
 	presignedURL, err := s.Client.PresignedPutObject(ctx, bucket, fileKey, expiry)
 	if err != nil {
@@ -70,7 +71,7 @@ func (s *Strg) GeneratePresignedUploadURL(ctx context.Context, bucket, fileKey s
 }
 
 func (s *Strg) FileExists(ctx context.Context, bucket, fileKey string) (bool, error) {
-	log.Printf("checking if file %q exists in bucket %q...", fileKey, bucket)
+	logger.Debugf(ctx, "checking if file %q exists in bucket %q...", fileKey, bucket)
 
 	_, err := s.StatFile(ctx, bucket, fileKey)
 	if errors.Is(err, media.ErrObjectNotFound) {
@@ -83,7 +84,7 @@ func (s *Strg) FileExists(ctx context.Context, bucket, fileKey string) (bool, er
 }
 
 func (s *Strg) StatFile(ctx context.Context, bucket, fileKey string) (port.FileInfo, error) {
-	log.Printf("getting stats on file %q in bucket %q...", fileKey, bucket)
+	logger.Debugf(ctx, "getting stats on file %q in bucket %q...", fileKey, bucket)
 
 	info, err := s.Client.StatObject(ctx, bucket, fileKey, minio.StatObjectOptions{})
 	if err != nil {
@@ -96,14 +97,14 @@ func (s *Strg) StatFile(ctx context.Context, bucket, fileKey string) (port.FileI
 }
 
 func (s *Strg) RemoveFile(ctx context.Context, bucket, fileKey string) error {
-	log.Printf("removing file %q from bucket %q...", fileKey, bucket)
+	logger.Debugf(ctx, "removing file %q from bucket %q...", fileKey, bucket)
 
 	err := s.Client.RemoveObject(ctx, bucket, fileKey, minio.RemoveObjectOptions{})
 	return mapMinioErr(err)
 }
 
 func (s *Strg) GetFile(ctx context.Context, bucket, fileKey string) (io.ReadSeekCloser, error) {
-	log.Printf("getting file %q from bucket %q...", fileKey, bucket)
+	logger.Debugf(ctx, "getting file %q from bucket %q...", fileKey, bucket)
 
 	obj, err := s.Client.GetObject(ctx, bucket, fileKey, minio.GetObjectOptions{})
 	if err != nil {
@@ -113,7 +114,7 @@ func (s *Strg) GetFile(ctx context.Context, bucket, fileKey string) (io.ReadSeek
 }
 
 func (s *Strg) SaveFile(ctx context.Context, bucket, fileKey string, reader io.Reader, fileSize int64, opts map[string]string) error {
-	log.Printf("saving file %q into bucket %q...", fileKey, bucket)
+	logger.Debugf(ctx, "saving file %q into bucket %q...", fileKey, bucket)
 
 	putOpts := minio.PutObjectOptions{}
 	if ct := opts["Content-Type"]; ct != "" {
@@ -128,7 +129,7 @@ func (s *Strg) SaveFile(ctx context.Context, bucket, fileKey string, reader io.R
 }
 
 func (s *Strg) CopyFile(ctx context.Context, bucket, srcKey, destKey string) error {
-	log.Printf("copying file %q to %q inside bucket %q...", srcKey, destKey, bucket)
+	logger.Debugf(ctx, "copying file %q to %q inside bucket %q...", srcKey, destKey, bucket)
 
 	destOpts := minio.CopyDestOptions{
 		Bucket: bucket,

--- a/internal/usecase/media/delete_media.go
+++ b/internal/usecase/media/delete_media.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"log"
 
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type deleteMediaSrv struct {
@@ -36,7 +37,7 @@ func (s *deleteMediaSrv) DeleteMedia(ctx context.Context, id msuuid.UUID) error 
 
 	for _, v := range media.Variants {
 		if err := s.strg.RemoveFile(ctx, media.Bucket, v.ObjectKey); err != nil {
-			log.Printf("failed to remove variant %q: %v", v.ObjectKey, err)
+			logger.Warnf(ctx, "failed to remove variant %q: %v", v.ObjectKey, err)
 		}
 	}
 
@@ -49,10 +50,10 @@ func (s *deleteMediaSrv) DeleteMedia(ctx context.Context, id msuuid.UUID) error 
 	}
 
 	if err := s.cache.DeleteMediaDetails(ctx, media.ID); err != nil {
-		log.Printf("failed deleting cache for media #%s: %v", media.ID, err)
+		logger.Warnf(ctx, "failed deleting cache for media #%s: %v", media.ID, err)
 	}
 	if err := s.cache.DeleteEtagMediaDetails(ctx, media.ID); err != nil {
-		log.Printf("failed deleting etag cache for media #%s: %v", media.ID, err)
+		logger.Warnf(ctx, "failed deleting etag cache for media #%s: %v", media.ID, err)
 	}
 
 	return nil

--- a/internal/usecase/media/get_media.go
+++ b/internal/usecase/media/get_media.go
@@ -5,12 +5,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
 	msuuid "github.com/fhuszti/medias-ms-go/internal/uuid"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type mediaGetterSrv struct {
@@ -59,7 +60,7 @@ func (s *mediaGetterSrv) GetMedia(ctx context.Context, id msuuid.UUID) (*port.Ge
 		for _, v := range media.Variants {
 			vUrl, vErr := s.strg.GeneratePresignedDownloadURL(ctx, media.Bucket, v.ObjectKey, DownloadUrlTTL)
 			if vErr != nil {
-				log.Printf("error generating presigned download URL for variant %q: %+v", v.ObjectKey, vErr)
+				logger.Warnf(ctx, "error generating presigned download URL for variant %q: %+v", v.ObjectKey, vErr)
 				continue
 			}
 			variants = append(variants, model.VariantOutput{

--- a/internal/usecase/media/optimise_backlog.go
+++ b/internal/usecase/media/optimise_backlog.go
@@ -2,10 +2,11 @@ package media
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/fhuszti/medias-ms-go/internal/port"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type backlogOptimiserSrv struct {
@@ -31,13 +32,13 @@ func (s *backlogOptimiserSrv) OptimiseBacklog(ctx context.Context) error {
 	}
 
 	if len(ids) == 0 {
-		log.Printf("no medias found to optimise")
+		logger.Info(ctx, "no medias found to optimise")
 	}
 
 	for _, id := range ids {
-		log.Printf("starting optimisation for media #%s", id)
+		logger.Infof(ctx, "starting optimisation for media #%s", id)
 		if err := s.tasks.EnqueueOptimiseMedia(ctx, id); err != nil {
-			log.Printf("failed to enqueue optimise task for media #%s: %v", id, err)
+			logger.Warnf(ctx, "failed to enqueue optimise task for media #%s: %v", id, err)
 		}
 	}
 
@@ -47,13 +48,13 @@ func (s *backlogOptimiserSrv) OptimiseBacklog(ctx context.Context) error {
 	}
 
 	if len(resizeIDs) == 0 {
-		log.Printf("no images found to resize")
+		logger.Info(ctx, "no images found to resize")
 	}
 
 	for _, id := range resizeIDs {
-		log.Printf("starting resize for media #%s", id)
+		logger.Infof(ctx, "starting resize for media #%s", id)
 		if err := s.tasks.EnqueueResizeImage(ctx, id); err != nil {
-			log.Printf("failed to enqueue resize task for media #%s: %v", id, err)
+			logger.Warnf(ctx, "failed to enqueue resize task for media #%s: %v", id, err)
 		}
 	}
 	return nil

--- a/internal/usecase/media/resize_image.go
+++ b/internal/usecase/media/resize_image.go
@@ -6,12 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"path"
 	"strings"
 
 	"github.com/fhuszti/medias-ms-go/internal/model"
 	"github.com/fhuszti/medias-ms-go/internal/port"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type imageResizerSrv struct {
@@ -109,15 +110,15 @@ func (s *imageResizerSrv) ResizeImage(ctx context.Context, in port.ResizeImageIn
 	}
 
 	if err := s.repo.Update(ctx, media); err != nil {
-		log.Printf("failed updating media with variants: %v", err)
+		logger.Errorf(ctx, "failed updating media with variants: %v", err)
 		return fmt.Errorf("failed updating media: %w", err)
 	}
 
 	if err := s.cache.DeleteMediaDetails(ctx, media.ID); err != nil {
-		log.Printf("failed deleting cache for media #%s: %v", media.ID, err)
+		logger.Warnf(ctx, "failed deleting cache for media #%s: %v", media.ID, err)
 	}
 	if err := s.cache.DeleteEtagMediaDetails(ctx, media.ID); err != nil {
-		log.Printf("failed deleting etag cache for media #%s: %v", media.ID, err)
+		logger.Warnf(ctx, "failed deleting etag cache for media #%s: %v", media.ID, err)
 	}
 	return nil
 }

--- a/test/testutil/mariadb_container.go
+++ b/test/testutil/mariadb_container.go
@@ -1,13 +1,15 @@
 package testutil
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
-	"log"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type MariaDBContainerInfo struct {
@@ -66,7 +68,7 @@ func StartMariaDBContainer() (*MariaDBContainerInfo, error) {
 		DSN: dsn,
 		Cleanup: func() {
 			if err := pool.Purge(resource); err != nil {
-				log.Printf("could not purge container: %s", err)
+				logger.Warnf(context.Background(), "could not purge container: %s", err)
 			}
 		},
 	}

--- a/test/testutil/minio_container.go
+++ b/test/testutil/minio_container.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/fhuszti/medias-ms-go/internal/storage"
@@ -11,6 +10,8 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type MinIOContainerInfo struct {
@@ -82,7 +83,7 @@ func StartMinIOContainer() (*MinIOContainerInfo, error) {
 		Strg: strg,
 		Cleanup: func() {
 			if err := pool.Purge(resource); err != nil {
-				log.Printf("could not purge minio container: %s", err)
+				logger.Warnf(context.Background(), "could not purge minio container: %s", err)
 			}
 		},
 	}

--- a/test/testutil/redis_container.go
+++ b/test/testutil/redis_container.go
@@ -3,12 +3,13 @@ package testutil
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/redis/go-redis/v9"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 type RedisContainerInfo struct {
@@ -55,7 +56,7 @@ func StartRedisContainer() (*RedisContainerInfo, error) {
 		Addr: addr,
 		Cleanup: func() {
 			if err := pool.Purge(resource); err != nil {
-				log.Printf("could not purge redis container: %s", err)
+				logger.Warnf(context.Background(), "could not purge redis container: %s", err)
 			}
 		},
 	}

--- a/test/testutil/worker.go
+++ b/test/testutil/worker.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"context"
-	"log"
 
 	"github.com/fhuszti/medias-ms-go/internal/cache"
 	"github.com/fhuszti/medias-ms-go/internal/db"
@@ -13,6 +12,8 @@ import (
 	"github.com/fhuszti/medias-ms-go/internal/task"
 	mediaSvc "github.com/fhuszti/medias-ms-go/internal/usecase/media"
 	"github.com/hibiken/asynq"
+
+	"github.com/fhuszti/medias-ms-go/internal/logger"
 )
 
 // StartWorker starts an asynq worker processing optimisation tasks.
@@ -44,7 +45,7 @@ func StartWorker(dbConn *db.Database, strg *storage.Strg, redisAddr string) func
 	srv := asynq.NewServer(asynq.RedisClientOpt{Addr: redisAddr}, asynq.Config{Concurrency: 5})
 	go func() {
 		if err := srv.Run(mux); err != nil {
-			log.Printf("worker stopped: %v", err)
+			logger.Errorf(context.Background(), "worker stopped: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- replace standard library logging calls across the services and CLIs with the internal logger wrappers so logs include contextual metadata
- update handlers, storage, caches, and use cases to emit appropriate log levels via the unified logging helpers

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e43a7bac1883219f42b2113fd52fb5